### PR TITLE
paralllelizable linkconstraint

### DIFF
--- a/src/macros.jl
+++ b/src/macros.jl
@@ -63,6 +63,7 @@ macro node(graph,args...)
     return esc(code)
 end
 
+
 """
     @linkconstraint(graph::OptiGraph, expr)
 
@@ -75,7 +76,7 @@ Add a group of linking  constraints described by the expression `expr` parametri
 
 The @linkconstraint macro works the same way as the `JuMP.@constraint` macro.
 """
-macro linkconstraint(graph,args...)
+macro linkconstraint(graph_or_edge,args...)
     args, kw_args, requestedcontainer = Containers._extract_kw_args(args)
     attached_node_kw_args = filter(kw -> kw.args[1] == :attach, kw_args)
     #extra_kw_args = filter(kw -> kw.args[1] != :attach, kw_args)
@@ -87,8 +88,8 @@ macro linkconstraint(graph,args...)
     end
 
     code = quote
-        @assert isa($graph,AbstractOptiGraph)  #Check the inputs are the correct types.  This needs to throw
-        refs = JuMP.@constraint($graph,($(args...)))
+        @assert isa($graph_or_edge,Union{AbstractOptiGraph,OptiEdge})  #Check the inputs are the correct types.  This needs to throw
+        refs = JuMP.@constraint($graph_or_edge,($(args...)))
 
         #Set attached node if argument was provided
         if $attached_node != nothing


### PR DESCRIPTION
This change should allow parallel link constraint creation. To enable parallel linkconstraint creation, I deleted global linkconstraint counter and made it local to each optiedge. Also, this allows doing `@linkconstraint(optiedge,n1[:x]==n2[:x])`. The effect is the same as `@linkconstraint(graph,n1[:x]==n2[:x])`, but we can make sure that the parent graph is not referenced, thus parallel model building is not colliding with each other. Tests in `Plasmo.jl` are all passed but not sure if the solver interfaces are OK with this change. Let me know what you think :)