### PR TITLE
fix set_model. add alias query functions

### DIFF
--- a/src/Plasmo.jl
+++ b/src/Plasmo.jl
@@ -38,8 +38,10 @@ getedge, getoptiedge, getedges,  getoptiedges, all_edges, find_edge, all_edge, n
 
 add_subgraph!, getsubgraph, getsubgraphs, all_subgraphs, num_subgraphs, has_subgraphs,
 
+optinodes, optiedges, subgraphs, all_optinodes, all_optiedges,
+
 #Graph Functions
-incident_edges, neighborhood, induced_edges, expand,
+incident_edges, neighborhood, induced_edges, expand, induced_graph,
 
 #LinkConstraint
 LinkConstraint, LinkConstraintRef,

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -137,7 +137,7 @@ Retrieve the local subgraphs of `optigraph`.
 getsubgraphs(optigraph::OptiGraph) = OptiGraph[subgraph for subgraph in optigraph.subgraphs]
 num_subgraphs(optigraph::OptiGraph) = length(optigraph.subgraphs)
 getsubgraph(optigraph::OptiGraph,idx::Int64) = optigraph.subgraphs[idx]
-
+subgraphs(optigraph::OptiGraph) = getsubgraphs(optigraph)
 """
     all_subgraphs(optigraph::OptiGraph)::Vector{OptiGraph}
 
@@ -195,7 +195,7 @@ end
 Retrieve the optinodes in `graph`.
 """
 getnodes(graph::OptiGraph) = graph.optinodes
-
+optinodes(graph::OptiGraph) = getnodes(graph)
 """
     getnode(graph::OptiGraph) = graph.optinodes
 
@@ -215,7 +215,7 @@ function all_nodes(graph::OptiGraph)
     end
     return nodes
 end
-
+all_optinodes(graph::OptiGraph) = all_nodes(graph)
 """
     all_node(graph::OptiGraph,index::Int64)
 
@@ -272,6 +272,7 @@ add_edge!(graph::OptiGraph,optinodes::Vector{OptiNode}) = add_optiedge!(graph,op
 Retrieve the local optiedges in `graph`.
 """
 getedges(graph::OptiGraph) = graph.optiedges
+optiedges(graph::OptiGraph) = getedges(graph)
 
 """
     getedge(graph::OptiGraph,index::Int64)
@@ -305,6 +306,7 @@ function all_edges(graph::OptiGraph)
     end
     return edges
 end
+all_optiedges(graph::OptiGraph) = all_edges(graph)
 
 function all_edge(graph::OptiGraph,index::Int64)
     edges = all_nodes(graph)
@@ -380,6 +382,7 @@ function getlinkconstraints(graph::OptiGraph)
     end
     return links
 end
+linkconstraints(graph::OptiGraph) = getlinkconstraints(graph)
 num_link_constraints(graph::OptiGraph) = sum(num_link_constraints.(graph.optiedges))
 @deprecate num_linkconstraints num_link_constraints
 """

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -237,6 +237,13 @@ function Base.getindex(graph::OptiGraph,node::OptiNode)
     return graph.node_idx_map[node]
 end
 
+"""
+    Base.getindex(graph::OptiGraph,index::Int64)
+
+Retrieve the node at `index` in `graph`.
+"""
+Base.getindex(graph::OptiGraph,index::Int64) = getnode(graph,index)
+
 ###################################################
 #OptiEdges
 ###################################################

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -118,6 +118,8 @@ function set_model(node::OptiNode,m::JuMP.AbstractModel;preserve_links = false)
     !(is_set_to_node(m) && jump_model(node) == m) || error("Model $m is already asigned to another node")
     node.model = m
     m.ext[:optinode] = node
+    node_backend = NodeBackend(JuMP.backend(m),node.id)
+    m.moi_backend = node_backend
 end
 @deprecate setmodel set_model
 
@@ -144,6 +146,7 @@ end
 function Base.setindex!(node::OptiNode,value::Any,symbol::Symbol)
     setattribute(node,symbol,value)
 end
+setlabel(node::OptiNode,label::Symbol) = node.label = label
 
 JuMP.object_dictionary(m::OptiNode) = m.model.obj_dict
 JuMP.variable_type(::OptiNode) = JuMP.VariableRef

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -94,6 +94,10 @@ function test_set_model()
     @linkconstraint(graph,n1[:x] == n2[:x])
 
     @test num_variables(graph) == 3
+
+    set_optimizer(graph,Ipopt.Optimizer)
+    optimize!(graph)
+    @test termination_status(graph) == MOI.LOCALLY_SOLVED
 end
 
 function test_subgraph()


### PR DESCRIPTION
This PR should fix https://github.com/zavalab/Plasmo.jl/issues/39. It additionally adds some convenience query functions to get optigraph objects, namely: `optinodes`, `optiedges`, and `subgraphs` with corresponding functions `all_optinodes`,`all_optiedges`, and `all_subgraphs`.