### PR TITLE
Update for JuMP v0.22

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -16,10 +16,10 @@ version = "1.3.0"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BenchmarkTools]]
-deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
-git-tree-sha1 = "ffabdf5297c9038973a0a3724132aa269f38c448"
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "61adeb0823084487000600ef8b1c00cc2474cd47"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "1.1.0"
+version = "1.2.0"
 
 [[Bzip2_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -35,9 +35,9 @@ version = "0.5.1"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "aec96e79e396dfa7f762c90e3cac8f15ddb43f03"
+git-tree-sha1 = "2f294fae04aa5069a67964a3366e151e09ea7c09"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.10"
+version = "1.9.0"
 
 [[CodecBzip2]]
 deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
@@ -59,9 +59,9 @@ version = "0.3.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
+git-tree-sha1 = "31d0151f5716b655421d9d75b7fa74cc4e744df2"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.31.0"
+version = "3.39.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -91,9 +91,9 @@ version = "1.0.3"
 
 [[DiffRules]]
 deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "214c3fcac57755cfda163d91c58893a8723f93e9"
+git-tree-sha1 = "7220bc21c33e990c14f4a9a319b1d242ebc5b269"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.0.2"
+version = "1.3.1"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -106,31 +106,24 @@ uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.5"
 
 [[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "e2af66012e08966366a43251e1fd421522908be6"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "63777916efbcb0ab6173d09a658fb7f2783de485"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.18"
-
-[[HTTP]]
-deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "c6a1fff2fd4b1da29d3dccaffb1e1001244d844e"
-uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.12"
+version = "0.10.21"
 
 [[Inflate]]
 git-tree-sha1 = "f5fc07d4e706b84f72d54eedcc1c13d92fb0871c"
 uuid = "d25df0c9-e2be-5dd7-82c8-3ad0b3e990b9"
 version = "0.1.2"
 
-[[IniFile]]
-deps = ["Test"]
-git-tree-sha1 = "098e4d2c533924c921f9f9847274f2ad89e018b8"
-uuid = "83e8ac13-25f8-5344-8a64-a9f2b223428f"
-version = "0.5.0"
-
 [[InteractiveUtils]]
 deps = ["Markdown"]
 uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
@@ -140,21 +133,17 @@ version = "1.3.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
-
-[[JSONSchema]]
-deps = ["HTTP", "JSON", "ZipFile"]
-git-tree-sha1 = "b84ab8139afde82c7c65ba2b792fe12e01dd7307"
-uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.3"
+version = "0.21.2"
 
 [[JuMP]]
 deps = ["Calculus", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Printf", "Random", "SparseArrays", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "8dfc5df8aad9f2cfebc8371b69700efd02060827"
+git-tree-sha1 = "4630a959ba95c41bab326caac8d0d7098821f779"
+repo-rev = "master"
+repo-url = "https://github.com/jump-dev/JuMP.jl.git"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.21.8"
+version = "0.22.0"
 
 [[LibGit2]]
 deps = ["Printf"]
@@ -174,60 +163,49 @@ deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
-deps = ["DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "7bd5f6565d80b6bf753738d2bc40a5dfea072070"
+deps = ["ChainRulesCore", "DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "34dc30f868e368f8a17b728a1238f3fcda43931a"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.2.5"
+version = "0.3.3"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+git-tree-sha1 = "5a5bc6bf062f0f95e62d0fe0a2d99699fed82dd9"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.6"
+version = "0.5.8"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MathOptInterface]]
-deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "575644e3c05b258250bb599e57cf73bbf1062901"
+deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "Printf", "SparseArrays", "Test", "Unicode"]
+git-tree-sha1 = "4819019da9f42746851ddc39d90222d1dbe953b7"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.9.22"
-
-[[MbedTLS]]
-deps = ["Dates", "MbedTLS_jll", "Random", "Sockets"]
-git-tree-sha1 = "1c38e51c3d08ef2278062ebceade0e46cefc96fe"
-uuid = "739be429-bea8-5141-9913-cc70e7f3736d"
-version = "1.0.3"
-
-[[MbedTLS_jll]]
-deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
-git-tree-sha1 = "0eef589dd1c26a3ac9d753fe1a8bcad63f956fa6"
-uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
-version = "2.16.8+1"
+version = "0.10.3"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
 [[MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "3927848ccebcc165952dc0d9ac9aa274a87bfe01"
+git-tree-sha1 = "372e3a76d969e651ca70eb647bf0e303bc95d615"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "0.2.20"
+version = "0.2.21"
 
 [[NaNMath]]
 git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
 uuid = "77ba4419-2d1f-58cd-9bb1-8ffee604a2e3"
 version = "0.3.5"
 
-[[NetworkOptions]]
-git-tree-sha1 = "ed3157f48a05543cce9b241e1f2815f7e843d96e"
-uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
-version = "1.2.0"
+[[OpenLibm_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "d22054f66695fe580009c09e765175cbf7f13031"
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.7.1+0"
 
 [[OpenSpecFun_jll]]
 deps = ["Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "Pkg"]
@@ -242,9 +220,9 @@ version = "1.4.1"
 
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+git-tree-sha1 = "98f59ff3639b3d9485a03a72f3ab35bab9465720"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.1.0"
+version = "2.0.6"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -259,6 +237,10 @@ version = "1.2.2"
 [[Printf]]
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+
+[[Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
 
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
@@ -292,9 +274,9 @@ uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[SimpleTraits]]
 deps = ["InteractiveUtils", "MacroTools"]
-git-tree-sha1 = "daf7aec3fe3acb2131388f93a4c409b8c7f62226"
+git-tree-sha1 = "5d7e3f4e11935503d3ecaf7186eac40602e7d231"
 uuid = "699a6c99-e7fa-54fc-8d76-47d257e15c1d"
-version = "0.9.3"
+version = "0.9.4"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
@@ -304,16 +286,16 @@ deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
-git-tree-sha1 = "a50550fa3164a8c46747e62063b4d774ac1bcf49"
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "793793f1df98e3d7d554b65a107e9c9a6399a6ed"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.5.1"
+version = "1.7.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "896d55218776ab8f23fb7b222a5a4a946d4aafc2"
+git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.5"
+version = "1.2.13"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -331,14 +313,9 @@ uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.5"
-
-[[URIs]]
-git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
-uuid = "5c2747f8-b7ea-4ff2-ba2e-563bfd36b1d4"
-version = "1.3.0"
+version = "0.9.6"
 
 [[UUIDs]]
 deps = ["Random", "SHA"]
@@ -346,12 +323,6 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
-
-[[ZipFile]]
-deps = ["Libdl", "Printf", "Zlib_jll"]
-git-tree-sha1 = "c3a5637e27e914a7a445b8d0ad063d701931e9f7"
-uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-version = "0.9.3"
 
 [[Zlib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]

--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Plasmo"
 uuid = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"
 authors = ["Jordan Jalving <jhjalving@gmail.com>"]
 repo = "https://github.com/zavalab/Plasmo.jl.git"
-version = "0.4.0"
+version = "0.4.2"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -18,13 +18,12 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DataStructures = "0.18"
-JuMP = "0.19, 0.20, 0.21"
 LightGraphs = "~1.3"
-MathOptInterface = "~0.9"
 Reexport = "~0.2, 1"
 Requires = "~1.0, 1"
-
 julia = "1"
+JuMP = "0.22"
+MathOptInterface = "0.10"
 
 [extras]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"

--- a/examples/Manifest.toml
+++ b/examples/Manifest.toml
@@ -6,6 +6,17 @@ git-tree-sha1 = "370cafc70604b2522f2c7cf9915ebcd17b4cd38b"
 uuid = "ae81ac8f-d209-56e5-92de-9978fef736f9"
 version = "0.1.2+0"
 
+[[Adapt]]
+deps = ["LinearAlgebra"]
+git-tree-sha1 = "84918055d15b3114ede17ac6a7182f68870c16f7"
+uuid = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
+version = "3.3.1"
+
+[[ArgTools]]
+git-tree-sha1 = "bdf73eec6a88885256f282d48eafcad25d7de494"
+uuid = "0dad84c5-d112-42e6-8d28-ef12dabb789f"
+version = "1.1.1"
+
 [[Artifacts]]
 deps = ["Pkg"]
 git-tree-sha1 = "c30985d8821e0cd73870b17b0ed0ce6dc44cb744"
@@ -16,10 +27,10 @@ version = "1.3.0"
 uuid = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"
 
 [[BenchmarkTools]]
-deps = ["JSON", "Logging", "Printf", "Statistics", "UUIDs"]
-git-tree-sha1 = "ffabdf5297c9038973a0a3724132aa269f38c448"
+deps = ["JSON", "Logging", "Printf", "Profile", "Statistics", "UUIDs"]
+git-tree-sha1 = "61adeb0823084487000600ef8b1c00cc2474cd47"
 uuid = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
-version = "1.1.0"
+version = "1.2.0"
 
 [[BinaryProvider]]
 deps = ["Libdl", "Logging", "SHA"]
@@ -33,6 +44,17 @@ git-tree-sha1 = "c3598e525718abcc440f69cc6d5f60dda0a1b61e"
 uuid = "6e34b625-4abd-537c-b88f-471c36dfa7a0"
 version = "1.0.6+5"
 
+[[CEnum]]
+git-tree-sha1 = "215a9aa4a1f23fbd05b92769fdd62559488d70e9"
+uuid = "fa961155-64e5-5f13-b03f-caf6b980ea82"
+version = "0.4.1"
+
+[[Cairo_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Fontconfig_jll", "FreeType2_jll", "Glib_jll", "JLLWrappers", "LZO_jll", "Libdl", "Pixman_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "e2f47f6d8337369411569fd45ae5753ca10394c6"
+uuid = "83423d85-b0ee-5818-9007-b63ccbeb887a"
+version = "1.16.0+6"
+
 [[Calculus]]
 deps = ["LinearAlgebra"]
 git-tree-sha1 = "f641eb0a4f00c343bbc32346e1217b86f3ce9dad"
@@ -41,9 +63,9 @@ version = "0.5.1"
 
 [[ChainRulesCore]]
 deps = ["Compat", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "be770c08881f7bb928dfd86d1ba83798f76cf62a"
+git-tree-sha1 = "8d954297bc51cc64f15937c2093799c3617b73e4"
 uuid = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
-version = "0.10.9"
+version = "1.10.0"
 
 [[CodecBzip2]]
 deps = ["Bzip2_jll", "Libdl", "TranscodingStreams"]
@@ -58,16 +80,16 @@ uuid = "944b1d66-785c-5afd-91f1-9de20f533193"
 version = "0.7.0"
 
 [[ColorSchemes]]
-deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random", "StaticArrays"]
-git-tree-sha1 = "c8fd01e4b736013bc61b704871d20503b33ea402"
+deps = ["ColorTypes", "Colors", "FixedPointNumbers", "Random"]
+git-tree-sha1 = "a851fec56cb73cfdf43762999ec72eff5b86882a"
 uuid = "35d6a980-a343-548e-a6ea-1d62b119f2f4"
-version = "3.12.1"
+version = "3.15.0"
 
 [[ColorTypes]]
 deps = ["FixedPointNumbers", "Random"]
-git-tree-sha1 = "32a2b8af383f11cbb65803883837a149d10dfe8a"
+git-tree-sha1 = "024fe24d83e4a5bf5fc80501a314ce0d1aa35597"
 uuid = "3da002f7-5984-5a60-b8a6-cbb66c0b333f"
-version = "0.10.12"
+version = "0.11.0"
 
 [[Colors]]
 deps = ["ColorTypes", "FixedPointNumbers", "Reexport"]
@@ -83,9 +105,9 @@ version = "0.3.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "dc7dedc2c2aa9faf59a55c622760a25cbefbe941"
+git-tree-sha1 = "31d0151f5716b655421d9d75b7fa74cc4e744df2"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.31.0"
+version = "3.39.0"
 
 [[CompilerSupportLibraries_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -100,15 +122,20 @@ uuid = "d38c429a-6771-53c6-b99e-75d170b6e991"
 version = "0.5.7"
 
 [[DataAPI]]
-git-tree-sha1 = "ee400abb2298bd13bfc3df1c412ed228061a2385"
+git-tree-sha1 = "cc70b17275652eb47bc9e5f81635981f13cea5c8"
 uuid = "9a962f9c-6df0-11e9-0e5d-c546b8b5ee8a"
-version = "1.7.0"
+version = "1.9.0"
 
 [[DataStructures]]
 deps = ["Compat", "InteractiveUtils", "OrderedCollections"]
-git-tree-sha1 = "4437b64df1e0adccc3e5d1adbc3ac741095e4677"
+git-tree-sha1 = "7d9d316f04214f7efdbb6398d545446e246eff02"
 uuid = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
-version = "0.18.9"
+version = "0.18.10"
+
+[[DataValueInterfaces]]
+git-tree-sha1 = "bfc1187b79289637fa0ef6d4436ebdfe6905cbd6"
+uuid = "e2d170a0-9d28-54be-80f0-106bbe20a464"
+version = "1.0.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -126,9 +153,9 @@ version = "1.0.3"
 
 [[DiffRules]]
 deps = ["NaNMath", "Random", "SpecialFunctions"]
-git-tree-sha1 = "214c3fcac57755cfda163d91c58893a8723f93e9"
+git-tree-sha1 = "7220bc21c33e990c14f4a9a319b1d242ebc5b269"
 uuid = "b552c78f-8df3-52c6-915a-8e097449b14b"
-version = "1.0.2"
+version = "1.3.1"
 
 [[Distributed]]
 deps = ["Random", "Serialization", "Sockets"]
@@ -140,11 +167,29 @@ git-tree-sha1 = "a32185f5428d3986f47c2ab78b1f216d5e6cc96f"
 uuid = "ffbed154-4ef7-542d-bbb7-c09d3a79fcae"
 version = "0.8.5"
 
+[[Downloads]]
+deps = ["ArgTools", "LibCURL", "NetworkOptions"]
+git-tree-sha1 = "135bf1896be424235eadb17474b2a78331567f08"
+uuid = "f43a241f-c20a-4ad4-852c-f6b1247861c6"
+version = "1.5.1"
+
+[[EarCut_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "92d8f9f208637e8d2d28c664051a00569c01493d"
+uuid = "5ae413db-bbd1-5e63-b57d-d24a61df00f5"
+version = "2.1.5+1"
+
+[[Expat_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "1402e52fcda25064f51c77a9655ce8680b76acf0"
+uuid = "2e619515-83b5-522b-bb60-26c02a35a201"
+version = "2.2.7+6"
+
 [[FFMPEG]]
 deps = ["FFMPEG_jll"]
-git-tree-sha1 = "c82bef6fc01e30d500f588cd01d29bdd44f1924e"
+git-tree-sha1 = "b57e3acbe22f8484b4b5ff66a7499717fe1a9cc8"
 uuid = "c87230d0-a227-11e9-1b43-d7ebe4e7570a"
-version = "0.3.0"
+version = "0.4.1"
 
 [[FFMPEG_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "LAME_jll", "LibVPX_jll", "Libdl", "Ogg_jll", "OpenSSL_jll", "Opus_jll", "Pkg", "Zlib_jll", "libass_jll", "libfdk_aac_jll", "libvorbis_jll", "x264_jll", "x265_jll"]
@@ -158,11 +203,23 @@ git-tree-sha1 = "335bfdceacc84c5cdf16aadc768aa5ddfc5383cc"
 uuid = "53c48c17-4a7d-5ca2-90c5-79b7896eea93"
 version = "0.8.4"
 
+[[Fontconfig_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Expat_jll", "FreeType2_jll", "JLLWrappers", "Libdl", "Libuuid_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "35895cf184ceaab11fd778b4590144034a167a2f"
+uuid = "a3f928ae-7b40-5064-980b-68af3947d34b"
+version = "2.13.1+14"
+
+[[Formatting]]
+deps = ["Printf"]
+git-tree-sha1 = "8339d61043228fdd3eb658d86c926cb282ae72a8"
+uuid = "59287772-0a20-5a39-b81b-1366585eb4c0"
+version = "0.4.2"
+
 [[ForwardDiff]]
-deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
-git-tree-sha1 = "e2af66012e08966366a43251e1fd421522908be6"
+deps = ["CommonSubexpressions", "DiffResults", "DiffRules", "LinearAlgebra", "NaNMath", "Preferences", "Printf", "Random", "SpecialFunctions", "StaticArrays"]
+git-tree-sha1 = "63777916efbcb0ab6173d09a658fb7f2783de485"
 uuid = "f6369f11-7733-5829-9624-2563aa707210"
-version = "0.10.18"
+version = "0.10.21"
 
 [[FreeType2_jll]]
 deps = ["Artifacts", "Bzip2_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
@@ -176,23 +233,59 @@ git-tree-sha1 = "0d20aed5b14dd4c9a2453c1b601d08e1149679cc"
 uuid = "559328eb-81f9-559d-9380-de523a88c83c"
 version = "1.0.5+6"
 
+[[GLFW_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libglvnd_jll", "Pkg", "Xorg_libXcursor_jll", "Xorg_libXi_jll", "Xorg_libXinerama_jll", "Xorg_libXrandr_jll"]
+git-tree-sha1 = "a199aefead29c3c2638c3571a9993b564109d45a"
+uuid = "0656b61e-2033-5cc2-a64a-77c0f6c09b89"
+version = "3.3.4+0"
+
 [[GLPK]]
-deps = ["BinaryProvider", "Libdl", "MathOptInterface", "SparseArrays"]
-git-tree-sha1 = "3420033e843e140d9237238d69937a5bc7292e5a"
+deps = ["BinaryProvider", "CEnum", "GLPK_jll", "Libdl", "MathOptInterface"]
+git-tree-sha1 = "2bd86c95ad13ebe1f6811c52eb7273bd4310e99f"
 uuid = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
-version = "0.12.1"
+version = "0.15.0"
+
+[[GLPK_jll]]
+deps = ["Artifacts", "GMP_jll", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "01de09b070d4b8e3e1250c6542e16ed5cad45321"
+uuid = "e8aa6df9-e6ca-548a-97ff-1f85fc5b8b98"
+version = "5.0.0+0"
+
+[[GMP_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "15abc5f976569a1c9d651aff02f7222ef305eb2a"
+uuid = "781609d7-10c4-51f6-84f2-b8444358ff6d"
+version = "6.1.2+6"
 
 [[GR]]
-deps = ["Base64", "DelimitedFiles", "LinearAlgebra", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
-git-tree-sha1 = "7ea6f715b7caa10d7ee16f1cfcd12f3ccc74116a"
+deps = ["Base64", "DelimitedFiles", "GR_jll", "HTTP", "JSON", "Libdl", "LinearAlgebra", "Pkg", "Printf", "Random", "Serialization", "Sockets", "Test", "UUIDs"]
+git-tree-sha1 = "d189c6d2004f63fd3c91748c458b09f26de0efaa"
 uuid = "28b8d3ca-fb5f-59d9-8090-bfdbd6d07a71"
-version = "0.48.0"
+version = "0.61.0"
 
-[[GeometryTypes]]
-deps = ["ColorTypes", "FixedPointNumbers", "LinearAlgebra", "StaticArrays"]
-git-tree-sha1 = "07194161fe4e181c6bf51ef2e329ec4e7d050fc4"
-uuid = "4d00f742-c7ba-57c2-abde-4428a4b178cb"
-version = "0.8.4"
+[[GR_jll]]
+deps = ["Artifacts", "Bzip2_jll", "Cairo_jll", "FFMPEG_jll", "Fontconfig_jll", "GLFW_jll", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Libtiff_jll", "Pixman_jll", "Pkg", "Qt5Base_jll", "Zlib_jll", "libpng_jll"]
+git-tree-sha1 = "d59e8320c2747553788e4fc42231489cc602fa50"
+uuid = "d2c73de3-f751-5644-a686-071e5b155ba9"
+version = "0.58.1+0"
+
+[[GeometryBasics]]
+deps = ["EarCut_jll", "IterTools", "LinearAlgebra", "StaticArrays", "StructArrays", "Tables"]
+git-tree-sha1 = "58bcdf5ebc057b085e58d95c138725628dd7453c"
+uuid = "5c1252a2-5f33-56bf-86c9-59e7332b4326"
+version = "0.4.1"
+
+[[Gettext_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "8c14294a079216000a0bdca5ec5a447f073ddc9d"
+uuid = "78b55507-aeef-58d4-861c-77aaff3498b1"
+version = "0.20.1+7"
+
+[[Glib_jll]]
+deps = ["Artifacts", "Gettext_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Libiconv_jll", "Libmount_jll", "PCRE_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "04690cc5008b38ecbdfede949220bc7d9ba26397"
+uuid = "7746bdde-850d-59dc-9ae8-88ece973131d"
+version = "2.59.0+4"
 
 [[Grisu]]
 git-tree-sha1 = "53bb909d1151e57e2484c3d1b53e19552b887fb2"
@@ -201,9 +294,9 @@ version = "1.0.2"
 
 [[HTTP]]
 deps = ["Base64", "Dates", "IniFile", "Logging", "MbedTLS", "NetworkOptions", "Sockets", "URIs"]
-git-tree-sha1 = "c6a1fff2fd4b1da29d3dccaffb1e1001244d844e"
+git-tree-sha1 = "14eece7a3308b4d8be910e265c724a6ba51a9798"
 uuid = "cd3eb016-35fb-5094-929b-558a96fad6f3"
-version = "0.9.12"
+version = "0.9.16"
 
 [[IniFile]]
 deps = ["Test"]
@@ -217,15 +310,30 @@ uuid = "b77e0a4c-d291-57a0-90e8-8db25a27a240"
 
 [[Ipopt]]
 deps = ["BinaryProvider", "Ipopt_jll", "Libdl", "LinearAlgebra", "MathOptInterface", "MathProgBase"]
-git-tree-sha1 = "380786b4929b8d18d76e909c6b2eca355b7c3bd6"
+git-tree-sha1 = "539b23ab8fb86c6cc3e8cacaeb1f784415951be5"
 uuid = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
-version = "0.7.0"
+version = "0.8.0"
 
 [[Ipopt_jll]]
 deps = ["ASL_jll", "Artifacts", "CompilerSupportLibraries_jll", "JLLWrappers", "Libdl", "MUMPS_seq_jll", "OpenBLAS32_jll", "Pkg"]
 git-tree-sha1 = "82124f27743f2802c23fcb05febc517d0b15d86e"
 uuid = "9cc047cb-c261-5740-88fc-0cf96f7bdcc7"
 version = "3.13.4+2"
+
+[[IrrationalConstants]]
+git-tree-sha1 = "7fd44fd4ff43fc60815f8e764c0f352b83c49151"
+uuid = "92d709cd-6900-40b7-9082-c6be49f344b6"
+version = "0.1.1"
+
+[[IterTools]]
+git-tree-sha1 = "05110a2ab1fc5f932622ffea2a003221f4782c18"
+uuid = "c8e1da08-722c-5040-9ed9-7db0dc04731e"
+version = "1.3.0"
+
+[[IteratorInterfaceExtensions]]
+git-tree-sha1 = "a3f24677c21f5bbe9d2a714f95dcd58337fb2856"
+uuid = "82899510-4779-5014-852e-03e436cf321d"
+version = "1.0.0"
 
 [[JLLWrappers]]
 deps = ["Preferences"]
@@ -235,29 +343,35 @@ version = "1.3.0"
 
 [[JSON]]
 deps = ["Dates", "Mmap", "Parsers", "Unicode"]
-git-tree-sha1 = "81690084b6198a2e1da36fcfda16eeca9f9f24e4"
+git-tree-sha1 = "8076680b162ada2a031f707ac7b4953e30667a37"
 uuid = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
-version = "0.21.1"
+version = "0.21.2"
 
-[[JSONSchema]]
-deps = ["HTTP", "JSON", "ZipFile"]
-git-tree-sha1 = "b84ab8139afde82c7c65ba2b792fe12e01dd7307"
-uuid = "7d188eb4-7ad8-530c-ae41-71a32a6d4692"
-version = "0.3.3"
+[[JpegTurbo_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "9aff0587d9603ea0de2c6f6300d9f9492bbefbd3"
+uuid = "aacddb02-875f-59d6-b918-886e6ef4fbf8"
+version = "2.0.1+3"
 
 [[JuMP]]
 deps = ["Calculus", "DataStructures", "ForwardDiff", "JSON", "LinearAlgebra", "MathOptInterface", "MutableArithmetics", "NaNMath", "Printf", "Random", "SparseArrays", "SpecialFunctions", "Statistics"]
-git-tree-sha1 = "8dfc5df8aad9f2cfebc8371b69700efd02060827"
+git-tree-sha1 = "feb3bb6fdb487c096ddab1042c50468c693d1f4d"
+repo-rev = "master"
+repo-url = "https://github.com/jump-dev/JuMP.jl.git"
 uuid = "4076af6c-e467-56ae-b986-b466b2749572"
-version = "0.21.8"
+version = "0.22.0"
 
 [[KaHyPar]]
-deps = ["BinaryProvider", "Libdl", "LinearAlgebra", "SparseArrays"]
-git-tree-sha1 = "e8a3a75d5c9cc52acce28efa8dabc061254c7f86"
-repo-rev = "master"
-repo-url = "https://github.com/kahypar/KaHyPar.jl.git"
+deps = ["KaHyPar_jll", "Libdl", "LinearAlgebra", "SparseArrays"]
+git-tree-sha1 = "a9934172c61706d30837a967c2072d2203c73b54"
 uuid = "2a6221f6-aa48-11e9-3542-2d9e0ef01880"
-version = "0.1.0"
+version = "0.2.0"
+
+[[KaHyPar_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "boost_jll"]
+git-tree-sha1 = "5e488bff3bd9e77c29d634ed9250fb78ddbc5e07"
+uuid = "87a0c12d-51e1-52a8-b1ed-2b00825fe6a4"
+version = "1.2.1+0"
 
 [[LAME_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -265,9 +379,44 @@ git-tree-sha1 = "df381151e871f41ee86cee4f5f6fd598b8a68826"
 uuid = "c1c5ebd0-6772-5130-a774-d5fcae4a789d"
 version = "3.100.0+3"
 
+[[LZO_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f128cd6cd05ffd6d3df0523ed99b90ff6f9b349a"
+uuid = "dd4b983a-f0e5-5f8d-a1b7-129d4a5fb1ac"
+version = "2.10.0+3"
+
+[[LaTeXStrings]]
+git-tree-sha1 = "c7f1c695e06c01b95a67f0cd1d34994f3e7db104"
+uuid = "b964fa9f-0449-5b57-a5c2-d3ea65f4040f"
+version = "1.2.1"
+
+[[Latexify]]
+deps = ["Formatting", "InteractiveUtils", "LaTeXStrings", "MacroTools", "Markdown", "Printf", "Requires"]
+git-tree-sha1 = "a4b12a1bd2ebade87891ab7e36fdbce582301a92"
+uuid = "23fbe1c1-3f47-55db-b15f-69d7ec21a316"
+version = "0.15.6"
+
+[[LibCURL]]
+deps = ["LibCURL_jll", "MozillaCACerts_jll"]
+git-tree-sha1 = "cdbe7465ab7b52358804713a53c7fe1dac3f8a3f"
+uuid = "b27032c2-a3e7-50c8-80cd-2d36dbcbfd21"
+version = "0.6.3"
+
+[[LibCURL_jll]]
+deps = ["LibSSH2_jll", "Libdl", "MbedTLS_jll", "Pkg", "Zlib_jll", "nghttp2_jll"]
+git-tree-sha1 = "897d962c20031e6012bba7b3dcb7a667170dad17"
+uuid = "deac9b47-8bc7-5906-a0fe-35ac56dc84c0"
+version = "7.70.0+2"
+
 [[LibGit2]]
 deps = ["Printf"]
 uuid = "76f85450-5226-5b5a-8eaa-529ad045b433"
+
+[[LibSSH2_jll]]
+deps = ["Libdl", "MbedTLS_jll", "Pkg"]
+git-tree-sha1 = "717705533148132e5466f2924b9a3657b16158e8"
+uuid = "29816b5a-b9ab-546f-933c-edad1886dfa8"
+version = "1.9.0+3"
 
 [[LibVPX_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -278,15 +427,63 @@ version = "1.9.0+1"
 [[Libdl]]
 uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 
+[[Libffi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "a2cd088a88c0d37eef7d209fd3d8712febce0d90"
+uuid = "e9f186c6-92d2-5b65-8a66-fee21dc1b490"
+version = "3.2.1+4"
+
+[[Libgcrypt_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgpg_error_jll", "Pkg"]
+git-tree-sha1 = "b391a18ab1170a2e568f9fb8d83bc7c780cb9999"
+uuid = "d4300ac3-e22c-5743-9152-c294e39db1e4"
+version = "1.8.5+4"
+
+[[Libglvnd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll", "Xorg_libXext_jll"]
+git-tree-sha1 = "7739f837d6447403596a75d19ed01fd08d6f56bf"
+uuid = "7e76a0d4-f3c7-5321-8279-8d96eeed0f29"
+version = "1.3.0+3"
+
+[[Libgpg_error_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "ec7f2e8ad5c9fa99fc773376cdbc86d9a5a23cb7"
+uuid = "7add5ba3-2f88-524e-9cd5-f83b8a55f7b8"
+version = "1.36.0+3"
+
+[[Libiconv_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "cba7b560fcc00f8cd770fa85a498cbc1d63ff618"
+uuid = "94ce4f54-9a6c-5748-9c1c-f9c7231a4531"
+version = "1.16.0+8"
+
+[[Libmount_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "51ad0c01c94c1ce48d5cad629425035ad030bfd5"
+uuid = "4b2f31a3-9ecc-558c-b454-b3730dcb73e9"
+version = "2.34.0+3"
+
+[[Libtiff_jll]]
+deps = ["Artifacts", "JLLWrappers", "JpegTurbo_jll", "Libdl", "Pkg", "Zlib_jll", "Zstd_jll"]
+git-tree-sha1 = "291dd857901f94d683973cdf679984cdf73b56d0"
+uuid = "89763e89-9b03-5906-acba-b20f662cd828"
+version = "4.1.0+2"
+
+[[Libuuid_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f879ae9edbaa2c74c922e8b85bb83cc84ea1450b"
+uuid = "38a345b3-de98-5d2b-a5d3-14cd9215e700"
+version = "2.34.0+7"
+
 [[LinearAlgebra]]
 deps = ["Libdl"]
 uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 
 [[LogExpFunctions]]
-deps = ["DocStringExtensions", "LinearAlgebra"]
-git-tree-sha1 = "7bd5f6565d80b6bf753738d2bc40a5dfea072070"
+deps = ["ChainRulesCore", "DocStringExtensions", "IrrationalConstants", "LinearAlgebra"]
+git-tree-sha1 = "34dc30f868e368f8a17b728a1238f3fcda43931a"
 uuid = "2ab3a3ac-af41-5b50-aa03-7779005ae688"
-version = "0.2.5"
+version = "0.3.3"
 
 [[Logging]]
 uuid = "56ddb016-857b-54e1-b83d-db4d58db5568"
@@ -305,19 +502,19 @@ version = "5.2.1+4"
 
 [[MacroTools]]
 deps = ["Markdown", "Random"]
-git-tree-sha1 = "6a8a2a625ab0dea913aba95c11370589e0239ff0"
+git-tree-sha1 = "5a5bc6bf062f0f95e62d0fe0a2d99699fed82dd9"
 uuid = "1914dd2f-81c6-5fcd-8719-6d5c9610ff09"
-version = "0.5.6"
+version = "0.5.8"
 
 [[Markdown]]
 deps = ["Base64"]
 uuid = "d6f4376e-aef5-505a-96c1-9c027394607a"
 
 [[MathOptInterface]]
-deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "JSONSchema", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "SparseArrays", "Test", "Unicode"]
-git-tree-sha1 = "575644e3c05b258250bb599e57cf73bbf1062901"
+deps = ["BenchmarkTools", "CodecBzip2", "CodecZlib", "JSON", "LinearAlgebra", "MutableArithmetics", "OrderedCollections", "Printf", "SparseArrays", "Test", "Unicode"]
+git-tree-sha1 = "4819019da9f42746851ddc39d90222d1dbe953b7"
 uuid = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
-version = "0.9.22"
+version = "0.10.3"
 
 [[MathProgBase]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -344,18 +541,24 @@ version = "0.3.1"
 
 [[Missings]]
 deps = ["DataAPI"]
-git-tree-sha1 = "4ea90bd5d3985ae1f9a908bd4500ae88921c5ce7"
+git-tree-sha1 = "bf210ce90b6c9eed32d25dbcae1ebc565df2687f"
 uuid = "e1d29d7a-bbdc-5cf2-9ac0-f12de2c33e28"
-version = "1.0.0"
+version = "1.0.2"
 
 [[Mmap]]
 uuid = "a63ad114-7e13-5084-954f-fe012c677804"
 
+[[MozillaCACerts_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "f1662575f7bf53c73c2bbc763bace4b024de822c"
+uuid = "14a3606d-f60d-562e-9121-12d972cd8159"
+version = "2021.1.19+0"
+
 [[MutableArithmetics]]
 deps = ["LinearAlgebra", "SparseArrays", "Test"]
-git-tree-sha1 = "3927848ccebcc165952dc0d9ac9aa274a87bfe01"
+git-tree-sha1 = "8d9496b2339095901106961f44718920732616bb"
 uuid = "d8a4904e-b15c-11e9-3269-09a3773c0cb0"
-version = "0.2.20"
+version = "0.2.22"
 
 [[NaNMath]]
 git-tree-sha1 = "bfe47e760d60b82b66b61d2d44128b62e3a369fb"
@@ -378,6 +581,12 @@ deps = ["CompilerSupportLibraries_jll", "Libdl", "Pkg"]
 git-tree-sha1 = "793b33911239d2651c356c823492b58d6490d36a"
 uuid = "656ef2d0-ae68-5445-9ca0-591084a874a2"
 version = "0.3.9+4"
+
+[[OpenLibm_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "d22054f66695fe580009c09e765175cbf7f13031"
+uuid = "05823500-19ac-5b8b-9628-191a04bc5112"
+version = "0.7.1+0"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -402,11 +611,23 @@ git-tree-sha1 = "85f8e6578bf1f9ee0d11e7bb1b1456435479d47c"
 uuid = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 version = "1.4.1"
 
+[[PCRE_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "1b556ad51dceefdbf30e86ffa8f528b73c7df2bb"
+uuid = "2f80f16e-611a-54ab-bc61-aa92de5b98fc"
+version = "8.42.0+4"
+
 [[Parsers]]
 deps = ["Dates"]
-git-tree-sha1 = "c8abc88faa3f7a3950832ac5d6e690881590d6dc"
+git-tree-sha1 = "98f59ff3639b3d9485a03a72f3ab35bab9465720"
 uuid = "69de0a69-1ddd-5017-9359-2bf0b02dc9f0"
-version = "1.1.0"
+version = "2.0.6"
+
+[[Pixman_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6a20a83c1ae86416f0a5de605eaea08a552844a3"
+uuid = "30392449-352a-5448-841d-b1acce4e97dc"
+version = "0.40.0+0"
 
 [[Pkg]]
 deps = ["Dates", "LibGit2", "Libdl", "Logging", "Markdown", "Printf", "REPL", "Random", "SHA", "UUIDs"]
@@ -420,15 +641,15 @@ version = "2.0.1"
 
 [[PlotUtils]]
 deps = ["ColorSchemes", "Colors", "Dates", "Printf", "Random", "Reexport", "Statistics"]
-git-tree-sha1 = "ae9a295ac761f64d8c2ec7f9f24d21eb4ffba34d"
+git-tree-sha1 = "b084324b4af5a438cd63619fd006614b3b20b87b"
 uuid = "995b91a9-d308-5afd-9ec6-746e21dbc043"
-version = "1.0.10"
+version = "1.0.15"
 
 [[Plots]]
-deps = ["Base64", "Contour", "Dates", "FFMPEG", "FixedPointNumbers", "GR", "GeometryTypes", "JSON", "LinearAlgebra", "Measures", "NaNMath", "Pkg", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
-git-tree-sha1 = "80c3ec357366543e1600ce66a7d6645ec59d698d"
+deps = ["Base64", "Contour", "Dates", "Downloads", "FFMPEG", "FixedPointNumbers", "GR", "GeometryBasics", "JSON", "Latexify", "LinearAlgebra", "Measures", "NaNMath", "PlotThemes", "PlotUtils", "Printf", "REPL", "Random", "RecipesBase", "RecipesPipeline", "Reexport", "Requires", "Scratch", "Showoff", "SparseArrays", "Statistics", "StatsBase", "UUIDs"]
+git-tree-sha1 = "ba43b248a1f04a9667ca4a9f782321d9211aa68e"
 uuid = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
-version = "1.2.0"
+version = "1.22.6"
 
 [[Preferences]]
 deps = ["TOML"]
@@ -440,6 +661,16 @@ version = "1.2.2"
 deps = ["Unicode"]
 uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[[Profile]]
+deps = ["Printf"]
+uuid = "9abbd945-dff8-562f-b5e8-e1ebf5ef1b79"
+
+[[Qt5Base_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Fontconfig_jll", "Glib_jll", "JLLWrappers", "Libdl", "Libglvnd_jll", "OpenSSL_jll", "Pkg", "Xorg_libXext_jll", "Xorg_libxcb_jll", "Xorg_xcb_util_image_jll", "Xorg_xcb_util_keysyms_jll", "Xorg_xcb_util_renderutil_jll", "Xorg_xcb_util_wm_jll", "Zlib_jll", "xkbcommon_jll"]
+git-tree-sha1 = "16626cfabbf7206d60d84f2bf4725af7b37d4a77"
+uuid = "ea2cea3b-5b76-57ae-a6ef-0a8af62496e1"
+version = "5.15.2+0"
+
 [[REPL]]
 deps = ["InteractiveUtils", "Markdown", "Sockets"]
 uuid = "3fa0cd96-eef1-5676-8a61-b3b8758bbffb"
@@ -449,21 +680,20 @@ deps = ["Serialization"]
 uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 
 [[RecipesBase]]
-git-tree-sha1 = "b3fb709f3c97bfc6e948be68beeecb55a0b340ae"
+git-tree-sha1 = "44a75aa7a527910ee3d1751d1f0e4148698add9e"
 uuid = "3cdcf5f2-1ef4-517c-9805-6587b60abb01"
-version = "1.1.1"
+version = "1.1.2"
 
 [[RecipesPipeline]]
 deps = ["Dates", "NaNMath", "PlotUtils", "RecipesBase"]
-git-tree-sha1 = "4a325c9bcc2d8e62a8f975b9666d0251d53b63b9"
+git-tree-sha1 = "7ad0dfa8d03b7bcf8c597f59f5292801730c55b8"
 uuid = "01d81517-befc-4cb6-b9ec-a95719d0359c"
-version = "0.1.13"
+version = "0.4.1"
 
 [[Reexport]]
-deps = ["Pkg"]
-git-tree-sha1 = "7b1d07f411bc8ddb7977ec7f377b97b158514fe0"
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "0.2.0"
+version = "1.2.2"
 
 [[Requires]]
 deps = ["UUIDs"]
@@ -474,6 +704,12 @@ version = "1.1.3"
 [[SHA]]
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
+[[Scratch]]
+deps = ["Dates"]
+git-tree-sha1 = "0b4b7f1393cff97c33891da2a0bf69c6ed241fda"
+uuid = "6c6a2e73-6563-6170-7368-637461726353"
+version = "1.1.0"
+
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
 
@@ -483,34 +719,34 @@ uuid = "1a1011a3-84de-559e-8e89-a11a2f7dc383"
 
 [[Showoff]]
 deps = ["Dates", "Grisu"]
-git-tree-sha1 = "ee010d8f103468309b8afac4abb9be2e18ff1182"
+git-tree-sha1 = "91eddf657aca81df9ae6ceb20b959ae5653ad1de"
 uuid = "992d4aef-0814-514b-bc4d-f2e9a6c4116f"
-version = "0.3.2"
+version = "1.0.3"
 
 [[Sockets]]
 uuid = "6462fe0b-24de-5631-8697-dd941f90decc"
 
 [[SortingAlgorithms]]
 deps = ["DataStructures"]
-git-tree-sha1 = "2ec1962eba973f383239da22e75218565c390a96"
+git-tree-sha1 = "b3363d7460f7d098ca0912c69b082f75625d7508"
 uuid = "a2af1166-a08f-5f64-846c-94a0d3cef48c"
-version = "1.0.0"
+version = "1.0.1"
 
 [[SparseArrays]]
 deps = ["LinearAlgebra", "Random"]
 uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [[SpecialFunctions]]
-deps = ["ChainRulesCore", "LogExpFunctions", "OpenSpecFun_jll"]
-git-tree-sha1 = "a50550fa3164a8c46747e62063b4d774ac1bcf49"
+deps = ["ChainRulesCore", "IrrationalConstants", "LogExpFunctions", "OpenLibm_jll", "OpenSpecFun_jll"]
+git-tree-sha1 = "793793f1df98e3d7d554b65a107e9c9a6399a6ed"
 uuid = "276daf66-3868-5448-9aa4-cd146d93841b"
-version = "1.5.1"
+version = "1.7.0"
 
 [[StaticArrays]]
 deps = ["LinearAlgebra", "Random", "Statistics"]
-git-tree-sha1 = "896d55218776ab8f23fb7b222a5a4a946d4aafc2"
+git-tree-sha1 = "3c76dde64d03699e074ac02eb2e8ba8254d428da"
 uuid = "90137ffa-7385-5640-81b9-e52037218182"
-version = "1.2.5"
+version = "1.2.13"
 
 [[Statistics]]
 deps = ["LinearAlgebra", "SparseArrays"]
@@ -522,10 +758,16 @@ uuid = "82ae8749-77ed-4fe6-ae5f-f523153014b0"
 version = "1.0.0"
 
 [[StatsBase]]
-deps = ["DataAPI", "DataStructures", "LinearAlgebra", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
-git-tree-sha1 = "2f6792d523d7448bbe2fec99eca9218f06cc746d"
+deps = ["DataAPI", "DataStructures", "LinearAlgebra", "LogExpFunctions", "Missings", "Printf", "Random", "SortingAlgorithms", "SparseArrays", "Statistics", "StatsAPI"]
+git-tree-sha1 = "eb35dcc66558b2dda84079b9a1be17557d32091a"
 uuid = "2913bbd2-ae8a-5f71-8c99-4fb6c76f3a91"
-version = "0.33.8"
+version = "0.33.12"
+
+[[StructArrays]]
+deps = ["Adapt", "DataAPI", "StaticArrays", "Tables"]
+git-tree-sha1 = "2ce41e0d042c60ecd131e9fb7154a3bfadbf50d3"
+uuid = "09ab397b-f2b6-538f-b94a-2f83cf4a842a"
+version = "0.6.3"
 
 [[TOML]]
 deps = ["Dates"]
@@ -533,15 +775,27 @@ git-tree-sha1 = "44aaac2d2aec4a850302f9aa69127c74f0c3787e"
 uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 version = "1.0.3"
 
+[[TableTraits]]
+deps = ["IteratorInterfaceExtensions"]
+git-tree-sha1 = "c06b2f539df1c6efa794486abfb6ed2022561a39"
+uuid = "3783bdb8-4a98-5b6b-af9a-565f29a5fe9c"
+version = "1.0.1"
+
+[[Tables]]
+deps = ["DataAPI", "DataValueInterfaces", "IteratorInterfaceExtensions", "LinearAlgebra", "TableTraits", "Test"]
+git-tree-sha1 = "fed34d0e71b91734bf0a7e10eb1bb05296ddbcd0"
+uuid = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
+version = "1.6.0"
+
 [[Test]]
 deps = ["Distributed", "InteractiveUtils", "Logging", "Random"]
 uuid = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [[TranscodingStreams]]
 deps = ["Random", "Test"]
-git-tree-sha1 = "7c53c35547de1c5b9d46a4797cf6d8253807108c"
+git-tree-sha1 = "216b95ea110b5972db65aa90f88d8d89dcb8851c"
 uuid = "3bb67fe8-82b1-5028-8e26-92a6c54297fa"
-version = "0.9.5"
+version = "0.9.6"
 
 [[URIs]]
 git-tree-sha1 = "97bbe755a53fe859669cd907f2d96aee8d2c1355"
@@ -555,17 +809,173 @@ uuid = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 [[Unicode]]
 uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
 
-[[ZipFile]]
-deps = ["Libdl", "Printf", "Zlib_jll"]
-git-tree-sha1 = "c3a5637e27e914a7a445b8d0ad063d701931e9f7"
-uuid = "a5390f91-8eb1-5f08-bee0-b1d1ffed6cea"
-version = "0.9.3"
+[[Wayland_jll]]
+deps = ["Artifacts", "Expat_jll", "JLLWrappers", "Libdl", "Libffi_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "dc643a9b774da1c2781413fd7b6dcd2c56bb8056"
+uuid = "a2964d1f-97da-50d4-b82a-358c7fce9d89"
+version = "1.17.0+4"
+
+[[Wayland_protocols_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll"]
+git-tree-sha1 = "2839f1c1296940218e35df0bbb220f2a79686670"
+uuid = "2381bf8a-dfd0-557d-9999-79630e7b1b91"
+version = "1.18.0+4"
+
+[[XML2_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libiconv_jll", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "be0db24f70aae7e2b89f2f3092e93b8606d659a6"
+uuid = "02c8fc9c-b97f-50b9-bbe4-9be30ff0a78a"
+version = "2.9.10+3"
+
+[[XSLT_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Libgcrypt_jll", "Libgpg_error_jll", "Pkg", "XML2_jll"]
+git-tree-sha1 = "2b3eac39df218762d2d005702d601cd44c997497"
+uuid = "aed1982a-8fda-507f-9586-7b0439959a61"
+version = "1.1.33+4"
+
+[[Xorg_libX11_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll", "Xorg_xtrans_jll"]
+git-tree-sha1 = "5be649d550f3f4b95308bf0183b82e2582876527"
+uuid = "4f6342f7-b3d2-589e-9d20-edeb45f2b2bc"
+version = "1.6.9+4"
+
+[[Xorg_libXau_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4e490d5c960c314f33885790ed410ff3a94ce67e"
+uuid = "0c0b7dd1-d40b-584c-a123-a41640f87eec"
+version = "1.0.9+4"
+
+[[Xorg_libXcursor_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXfixes_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "12e0eb3bc634fa2080c1c37fccf56f7c22989afd"
+uuid = "935fb764-8cf2-53bf-bb30-45bb1f8bf724"
+version = "1.2.0+4"
+
+[[Xorg_libXdmcp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "4fe47bd2247248125c428978740e18a681372dd4"
+uuid = "a3789734-cfe1-5b06-b2d0-1dd0d9d62d05"
+version = "1.1.3+4"
+
+[[Xorg_libXext_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "b7c0aa8c376b31e4852b360222848637f481f8c3"
+uuid = "1082639a-0dae-5f34-9b06-72781eeb8cb3"
+version = "1.3.4+4"
+
+[[Xorg_libXfixes_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "0e0dc7431e7a0587559f9294aeec269471c991a4"
+uuid = "d091e8ba-531a-589c-9de9-94069b037ed8"
+version = "5.0.3+4"
+
+[[Xorg_libXi_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXfixes_jll"]
+git-tree-sha1 = "89b52bc2160aadc84d707093930ef0bffa641246"
+uuid = "a51aa0fd-4e3c-5386-b890-e753decda492"
+version = "1.7.10+4"
+
+[[Xorg_libXinerama_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll"]
+git-tree-sha1 = "26be8b1c342929259317d8b9f7b53bf2bb73b123"
+uuid = "d1454406-59df-5ea1-beac-c340f2130bc3"
+version = "1.1.4+4"
+
+[[Xorg_libXrandr_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libXext_jll", "Xorg_libXrender_jll"]
+git-tree-sha1 = "34cea83cb726fb58f325887bf0612c6b3fb17631"
+uuid = "ec84b674-ba8e-5d96-8ba1-2a689ba10484"
+version = "1.5.2+4"
+
+[[Xorg_libXrender_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "19560f30fd49f4d4efbe7002a1037f8c43d43b96"
+uuid = "ea2f1a96-1ddc-540d-b46f-429655e07cfa"
+version = "0.9.10+4"
+
+[[Xorg_libpthread_stubs_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "6783737e45d3c59a4a4c4091f5f88cdcf0908cbb"
+uuid = "14d82f49-176c-5ed1-bb49-ad3f5cbd8c74"
+version = "0.1.0+3"
+
+[[Xorg_libxcb_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "XSLT_jll", "Xorg_libXau_jll", "Xorg_libXdmcp_jll", "Xorg_libpthread_stubs_jll"]
+git-tree-sha1 = "daf17f441228e7a3833846cd048892861cff16d6"
+uuid = "c7cfdc94-dc32-55de-ac96-5a1b8d977c5b"
+version = "1.13.0+3"
+
+[[Xorg_libxkbfile_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libX11_jll"]
+git-tree-sha1 = "926af861744212db0eb001d9e40b5d16292080b2"
+uuid = "cc61e674-0454-545c-8b26-ed2c68acab7a"
+version = "1.1.0+4"
+
+[[Xorg_xcb_util_image_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "0fab0a40349ba1cba2c1da699243396ff8e94b97"
+uuid = "12413925-8142-5f55-bb0e-6d7ca50bb09b"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxcb_jll"]
+git-tree-sha1 = "e7fd7b2881fa2eaa72717420894d3938177862d1"
+uuid = "2def613f-5ad1-5310-b15b-b15d46f528f5"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_keysyms_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "d1151e2c45a544f32441a567d1690e701ec89b00"
+uuid = "975044d2-76e6-5fbe-bf08-97ce7c6574c7"
+version = "0.4.0+1"
+
+[[Xorg_xcb_util_renderutil_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "dfd7a8f38d4613b6a575253b3174dd991ca6183e"
+uuid = "0d47668e-0667-5a69-a72c-f761630bfb7e"
+version = "0.3.9+1"
+
+[[Xorg_xcb_util_wm_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xcb_util_jll"]
+git-tree-sha1 = "e78d10aab01a4a154142c5006ed44fd9e8e31b67"
+uuid = "c22f9ab0-d5fe-5066-847c-f4bb1cd4e361"
+version = "0.4.1+1"
+
+[[Xorg_xkbcomp_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_libxkbfile_jll"]
+git-tree-sha1 = "4bcbf660f6c2e714f87e960a171b119d06ee163b"
+uuid = "35661453-b289-5fab-8a00-3d9160c6a3a4"
+version = "1.4.2+4"
+
+[[Xorg_xkeyboard_config_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Xorg_xkbcomp_jll"]
+git-tree-sha1 = "5c8424f8a67c3f2209646d4425f3d415fee5931d"
+uuid = "33bec58e-1273-512f-9401-5d533626f822"
+version = "2.27.0+4"
+
+[[Xorg_xtrans_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "79c31e7844f6ecf779705fbc12146eb190b7d845"
+uuid = "c5fb5394-a638-5e4d-96e5-b29de1b5cf10"
+version = "1.4.0+3"
 
 [[Zlib_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "320228915c8debb12cb434c59057290f0834dbf6"
 uuid = "83775a58-1f1d-513f-b197-d71354ab007a"
 version = "1.2.11+18"
+
+[[Zstd_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "2c1332c54931e83f8f94d310fa447fd743e8d600"
+uuid = "3161d3a3-bdf6-5164-811a-617609db77b4"
+version = "1.4.8+0"
+
+[[boost_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
+git-tree-sha1 = "95bda308f7f69473c3c98b0cf4cf19e19a88cd49"
+uuid = "28df3c45-c428-5900-9ff8-a3135698ca75"
+version = "1.71.0+3"
 
 [[libass_jll]]
 deps = ["Artifacts", "Bzip2_jll", "FreeType2_jll", "FriBidi_jll", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
@@ -579,11 +989,23 @@ git-tree-sha1 = "7a5780a0d9c6864184b3a2eeeb833a0c871f00ab"
 uuid = "f638f0a6-7fb0-5443-88ba-1cc74229b280"
 version = "0.1.6+4"
 
+[[libpng_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Zlib_jll"]
+git-tree-sha1 = "6abbc424248097d69c0c87ba50fcb0753f93e0ee"
+uuid = "b53b4c65-9356-5827-b1ea-8c7a1a84506f"
+version = "1.6.37+6"
+
 [[libvorbis_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Ogg_jll", "Pkg"]
 git-tree-sha1 = "fa14ac25af7a4b8a7f61b287a124df7aab601bcd"
 uuid = "f27f6e37-5d2b-51aa-960f-b287f2bc3b7a"
 version = "1.3.6+6"
+
+[[nghttp2_jll]]
+deps = ["Libdl", "Pkg"]
+git-tree-sha1 = "8e2c44ab4d49ad9518f359ed8b62f83ba8beede4"
+uuid = "8e850ede-7688-5339-a07c-302acd2aaf8d"
+version = "1.40.0+2"
 
 [[x264_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -596,3 +1018,9 @@ deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
 git-tree-sha1 = "487da2f8f2f0c8ee0e83f39d13037d6bbf0a45ab"
 uuid = "dfaa095f-4041-5dcd-9319-2fabd8486b76"
 version = "3.0.0+3"
+
+[[xkbcommon_jll]]
+deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg", "Wayland_jll", "Wayland_protocols_jll", "Xorg_libxcb_jll", "Xorg_xkeyboard_config_jll"]
+git-tree-sha1 = "ece2350174195bb31de1a63bea3a41ae1aa593b6"
+uuid = "d8fb68d0-12a3-5cfd-a85a-d49703b185fd"
+version = "0.9.1+5"

--- a/src/Plasmo.jl
+++ b/src/Plasmo.jl
@@ -38,8 +38,10 @@ getedge, getoptiedge, getedges,  getoptiedges, all_edges, find_edge, all_edge, n
 
 add_subgraph!, getsubgraph, getsubgraphs, all_subgraphs, num_subgraphs, has_subgraphs,
 
+optinodes, optiedges, subgraphs, all_optinodes, all_optiedges,
+
 #Graph Functions
-incident_edges, neighborhood, induced_edges, expand,
+incident_edges, neighborhood, induced_edges, expand, induced_graph,
 
 #LinkConstraint
 LinkConstraint, LinkConstraintRef,

--- a/src/aggregate_utils.jl
+++ b/src/aggregate_utils.jl
@@ -48,13 +48,13 @@ function _to_expression(func::JuMP.GenericAffExpr)
 end
 
 function _copy_nl_objective(d::JuMP.NLPEvaluator,reference_map::AggregateMap)
-    if d.m.nlp_data.nlobj == nothing
-        new_obj = _to_expression(JuMP.objective_function(d.m))
+    if d.model.nlp_data.nlobj == nothing
+        new_obj = _to_expression(JuMP.objective_function(d.model))
     else
         new_obj = MOI.objective_expr(d)
     end
-        _splice_nonlinear_variables!(new_obj,getnode(d.m),reference_map)
-        JuMP.objective_sense(d.m) == MOI.MAX_SENSE ? sense = -1 : sense = 1
+        _splice_nonlinear_variables!(new_obj,getnode(d.model),reference_map)
+        JuMP.objective_sense(d.model) == MOI.MAX_SENSE ? sense = -1 : sense = 1
         new_obj = Expr(:call,:*,:($sense),new_obj)
     return new_obj
 end

--- a/src/aggregate_utils.jl
+++ b/src/aggregate_utils.jl
@@ -134,6 +134,10 @@ end
 function _copy_node(node::OptiNode)
     new_node = OptiNode()
     reference_map = AggregateMap()
-    node_ref_map = _add_to_combined_model!(new_node,node,reference_map)
+    temp_graph = OptiGraph()
+    add_node!(temp_graph,node)
+    new_node,reference_map = aggregate(temp_graph)
+    #_add_to_combined_model!(new_node,node,reference_map)
+    #_add_to_aggregate_node!(new_node,node,reference_map,graph_obj)
     return new_node,reference_map
 end

--- a/src/macros.jl
+++ b/src/macros.jl
@@ -1,5 +1,17 @@
 using Base.Meta
 
+#macro function helpers
+_get_name(c::Symbol) = c
+_get_name(c::Nothing) = ()
+_get_name(c::AbstractString) = c
+function _get_name(c::Expr)
+    if c.head == :string
+        return c
+    else
+        return c.args[1]
+    end
+end
+
 """
     @optinode(optigraph, expr...)
 
@@ -10,48 +22,32 @@ Add a new optinode to `optigraph`. The expression `expr` can either be
 
 """
 macro optinode(graph,args...)
-     _error(str...) = JuMP._macro_error(:node, args, str...)
-
+    #check arguments
     @assert length(args) <= 1
-    extra = collect(args)
-
-    if length(extra) == 0
-        x = gensym()
+    #get the name passed into the macro expression
+    if length(args) == 0
+        macro_code = :(add_node!($graph))
     else
-        x = popfirst!(extra)
-    end
-    nodeexpr = x
-
-    name = _get_name(nodeexpr)
-    namekey = string(name)
-    node = gensym()
-
-    if isa(nodeexpr, Symbol) # Easy case - a single node
-        nodecall = :(add_node!($graph))
-        macro_code = :($name = $nodecall)
-    else
-        isa(nodeexpr, Expr) || _error("Expected $node to be a node name")
-
-        # We now build the code to generate the optinodes
-        idxnodes, indices = _build_ref_sets(nodeexpr, node)
-        container_code = JuMP.Containers.generate_container(OptiNode,idxnodes,indices,:Auto)
+        var = string(_get_name(args[1]))
         macro_code = quote
-            $name = $(container_code[1])
-            if isa($name,JuMP.Containers.DenseAxisArray)
-                for index in 1:length($name.data)
-                    $name.data[index] = add_node!($graph;label = $(namekey)*"$index")
-                end
+            container = JuMP.Containers.@container($(args...),add_node!($graph))
+            #set node labels
+            if isa(container,OptiNode)
+                container.label = $var
             else
-                for index in 1:length($name)
-                    $name[index] = add_node!($graph;label = $(namekey)*"[$index]")
+                axs = axes(container)
+                terms = collect(Base.Iterators.product(axs...))[:]
+                for (i,node) in enumerate(container)
+                    node.label = $var*"[$(string(terms[i]...))]"
                 end
             end
-            $graph.obj_dict[Symbol($namekey)] = $name
+            $(graph).obj_dict[Symbol($var)] = container
         end
     end
     return esc(macro_code)
 end
 
+#node is deprecated
 macro node(graph,args...)
     code = quote
         @warn "@node is deprecated.  Use @optinode for future applications"
@@ -59,7 +55,6 @@ macro node(graph,args...)
     end
     return esc(code)
 end
-
 
 """
     @linkconstraint(graph::OptiGraph, expr)
@@ -76,7 +71,6 @@ The @linkconstraint macro works the same way as the `JuMP.@constraint` macro.
 macro linkconstraint(graph_or_edge,args...)
     args, kw_args, requestedcontainer = Containers._extract_kw_args(args)
     attached_node_kw_args = filter(kw -> kw.args[1] == :attach, kw_args)
-    #mpi_kw_args = filter(kw -> kw.args[1] == :mpi, kw_args)
     #extra_kw_args = filter(kw -> kw.args[1] != :attach, kw_args)
 
     #check for attached node argumentss
@@ -85,15 +79,6 @@ macro linkconstraint(graph_or_edge,args...)
     else
         attached_node = nothing
     end
-
-    # #check for mpi arguments
-    # if length(mpi_kw_args) > 0
-    #     mpi = mpi_kw_args[1].args[2]
-    # else
-    #     mpi = false
-    # end
-
-    #Manipulate args if mpi is true
 
     code = quote
         @assert isa($graph_or_edge,Union{AbstractOptiGraph,OptiEdge})  #Check the inputs are the correct types.  This needs to throw
@@ -140,111 +125,3 @@ macro NLnodeobjective(node,args...)
     end
     return esc(code)
 end
-#macro function helpers
-function _build_ref_sets(expr::Expr, cname)
-    c = copy(expr)
-    idxvars = Any[]
-    idxsets = Any[]
-    # Creating an indexed set of refs
-    # On 0.7, :(t[i;j]) is a :ref, while t[i,j;j] is a :typed_vcat.
-    # In both cases :t is the first arg.
-    if isexpr(c, :typed_vcat) || isexpr(c, :ref)
-        popfirst!(c.args)
-    end
-
-    for s in c.args
-        parse_done = false
-        if isa(s, Expr)
-            parse_done, idxvar, _idxset = _try_parse_idx_set(s::Expr)
-            if parse_done
-                idxset = _idxset
-            end
-        end
-        if !parse_done # No index variable specified
-            idxvar = gensym()
-            idxset = s
-        end
-        push!(idxvars, idxvar)
-        push!(idxsets, idxset)
-    end
-    return idxvars, idxsets
-end
-
-_build_ref_sets(c, cname)  = (cname, Any[], Any[], :())
-_build_ref_sets(c) = _build_ref_sets(c, _get_name(c))
-
-function _try_parse_idx_set(arg::Expr)
-    # [i=1] and x[i=1] parse as Expr(:vect, Expr(:(=), :i, 1)) and
-    # Expr(:ref, :x, Expr(:kw, :i, 1)) respectively.
-    if arg.head === :kw || arg.head === :(=)
-        @assert length(arg.args) == 2
-        return true, arg.args[1], arg.args[2]
-    elseif isexpr(arg, :call) && arg.args[1] === :in
-        return true, arg.args[2], arg.args[3]
-    else
-        return false, nothing, nothing
-    end
-end
-
-function _parse_idx_set(arg::Expr)
-    parse_done, idxvar, idxset = _try_parse_idx_set(arg)
-    if parse_done
-        return idxvar, idxset
-    end
-    error("Invalid syntax: $arg")
-end
-
-_get_name(c::Symbol) = c
-_get_name(c::Nothing) = ()
-_get_name(c::AbstractString) = c
-function _get_name(c::Expr)
-    if c.head == :string
-        return c
-    else
-        return c.args[1]
-    end
-end
-
-#TODO: parallel model building
-#@blas_safe_threads
-# const blas_num_threads = Ref{Int}()
-# function set_blas_num_threads(n::Integer;permanent::Bool=false)
-#     permanent && (blas_num_threads[]=n)
-#     BLAS.set_num_threads(n) # might be mkl64 or openblas64
-#     ccall((:mkl_set_dynamic, libmkl32),
-#           Cvoid,
-#           (Ptr{Int32},),
-#           Ref{Int32}(0))
-#     ccall((:mkl_set_num_threads, libmkl32),
-#           Cvoid,
-#           (Ptr{Int32},),
-#           Ref{Int32}(n))
-#     ccall((:openblas_set_num_threads, libopenblas32),
-#           Cvoid,
-#           (Ptr{Int32},),
-#           Ref{Int32}(n))
-# end
-# macro blas_safe_threads(args...)
-#     code = quote
-#         set_blas_num_threads(1)
-#         Threads.@threads($(args...))
-#         set_blas_num_threads(blas_num_threads[])
-#     end
-#     return esc(code)
-# end
-
-# macro NLnodeconstraint(node,args...)
-#     code = quote
-#         @assert isa($node,OptiNode)  #Check the inputs are the correct types.  This needs to throw
-#         JuMP.@NLconstraint((getmodel($node)),($(args...)))  #link model extends @constraint macro
-#     end
-#     return esc(code)
-# end
-
-# macro NLnodeobjective(node,args...)
-#     code = quote
-#         @assert isa($node,OptiNode)  #Check the inputs are the correct types.  This needs to throw
-#         JuMP.@NLobjective((getmodel($node)),($(args...)))  #link model extends @constraint macro
-#     end
-#     return esc(code)
-# end

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -122,7 +122,15 @@ MOI.is_valid(node_backend::NodeBackend,idx::MOI.Index) = MOI.is_valid(node_backe
 MOI.supports_constraint(node_backend::NodeBackend,func::Type{T}
     where T<:MathOptInterface.AbstractFunction, set::Type{S}
     where S <: MathOptInterface.AbstractSet) = MOI.supports_constraint(node_backend.optimizer,func,set)
-MOI.supports(node_backend::NodeBackend, attr::Union{MOI.AbstractModelAttribute, MOI.AbstractOptimizerAttribute}) = MOI.supports(node_backend.optimizer,attr)
+MOI.supports(node_backend::NodeBackend,
+            attr::Union{MOI.AbstractModelAttribute,
+            MOI.AbstractOptimizerAttribute}) =
+            MOI.supports(node_backend.optimizer,attr)
+MOI.supports(node_backend::NodeBackend,
+            attr::MOI.AbstractVariableAttribute,
+            idx = MOI.VariableIndex) =
+            MOI.supports(node_backend.optimizer,attr,idx)
+
 MOIU.attach_optimizer(node_backend::NodeBackend) = MOIU.attach_optimizer(node_backend.optimizer)
 MOIU.drop_optimizer(node_backend::NodeBackend) = MOIU.drop_optimizer(node_backend.optimizer)
 MOIU.reset_optimizer(node_backend::NodeBackend,args...) = MOIU.reset_optimizer(node_backend.optimizer,args...)

--- a/src/nlp_evaluator.jl
+++ b/src/nlp_evaluator.jl
@@ -143,7 +143,7 @@ function _get_nnz_hess_quad(d_node::JuMP.NLPEvaluator)
     if d_node.has_nlobj
         return _get_nnz_hess(d_node)
     else
-        return _get_nnz_hess(d_node) + _get_nnz_hess(objective_function(d_node.m))
+        return _get_nnz_hess(d_node) + _get_nnz_hess(objective_function(d_node.model))
     end
 end
 
@@ -206,7 +206,7 @@ function MOI.eval_objective_gradient(d::OptiGraphNLPEvaluator,grad,x)
                 if d.nlps[k].has_nlobj
                     MOI.eval_objective_gradient(d.nlps[k],view(grad,ninds[k]),view(x,ninds[k]))
                 else
-                    _fill_gradient!(objective_function(d.nlps[k].m),view(grad,ninds[k]),view(x,ninds[k]))
+                    _fill_gradient!(objective_function(d.nlps[k].model),view(grad,ninds[k]),view(x,ninds[k]))
                 end
             end
         else
@@ -283,7 +283,7 @@ end
 #Hessian Lagrangian structure with quadratic objective terms included
 function _hessian_lagrangian_structure_quad(d::JuMP.NLPEvaluator,I,J)
     if !(d.has_nlobj)
-        obj = objective_function(d.m)
+        obj = objective_function(d.model)
         offset = append_to_hessian_sparsity!(I,J,obj,1) + 1
     else
         offset = 1
@@ -360,7 +360,7 @@ end
 _eval_hessian_lagrangian(d::JuMP.NLPEvaluator,hess,x,sigma,mu) = MOI.eval_hessian_lagrangian(d,hess,x,sigma,mu)
 
 function _eval_hessian_lagrangian_quad(d::JuMP.NLPEvaluator,hess,x,sigma,mu)
-    offset = fill_hessian_lagrangian!(hess, 0, sigma, JuMP.objective_function(d.m))
+    offset = fill_hessian_lagrangian!(hess, 0, sigma, JuMP.objective_function(d.model))
     nlp_values = view(hess, 1 + offset : length(hess))
     MOI.eval_hessian_lagrangian(d, nlp_values, x, sigma, mu)
 end

--- a/src/optiedge.jl
+++ b/src/optiedge.jl
@@ -43,7 +43,7 @@ mutable struct OptiEdge <: AbstractOptiEdge
     linkrefs::Vector{AbstractLinkConstraintRef}
     #Link constraints
     linkconstraints::OrderedDict{Int64,LinkConstraint}
-    linkconstraint_names::Dict{Int64,String}
+    linkconstraint_names::OrderedDict{Int64,String}
     backend::EdgeBackend
     #TODO Capture nonlinear linking constraints
     #nlp_data::Union{Nothing,JuMP._NLPData}

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -12,13 +12,6 @@ end
 ##############################################################################
 # OptiGraph
 ##############################################################################
-#TODO: Set optigraph model attributes.  (e.g. set_optimizer_attribute(graph)) An optigraph can be solved just like any JuMP model in many cases.
-#IDEA: Update optigraph backend depending on state.  If we empty out a graph backend, we unhook the optinodes
-# @enum OptiGraphMode begin
-#     SYNCHRONIZED = 1   #optigraph backend is built up in parallel to optinodes
-#     NODES_ONLY = 2     #optigraph backend is not built.  We aggregates the backend if optimize!(graph) is called with an MOI optimizer.  This can be done with parallel threads.
-#     GRAPH_ONLY = 3     #optinode backend points to graph backend.  Less memory use.  Probably has to be done sequentially
-# end
 """
     OptiGraph()
 
@@ -50,9 +43,6 @@ mutable struct OptiGraph <: AbstractOptiGraph #<: JuMP.AbstractModel
     ext::Dict{Symbol,Any} #Extension Information
 
     id::Symbol
-
-    #TODO future release
-    #mode::OptiGraphMode
 
     #Constructor
     function OptiGraph()
@@ -616,7 +606,7 @@ function _add_to_partial_linkconstraint!(node::OptiNode,var::JuMP.VariableRef,co
     end
 end
 
-JuMP.constraint_type(::OptiGraph) = LinkConstraintRef
+# JuMP.constraint_type(::OptiGraph) = LinkConstraintRef
 function JuMP.add_bridge(graph::OptiGraph,BridgeType::Type{<:MOI.Bridges.AbstractBridge})
     push!(graph.bridge_types, BridgeType)
     #_moi_add_bridge(JuMP.backend(model), BridgeType)

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -127,7 +127,7 @@ Retrieve the local subgraphs of `optigraph`.
 getsubgraphs(optigraph::OptiGraph) = OptiGraph[subgraph for subgraph in optigraph.subgraphs]
 num_subgraphs(optigraph::OptiGraph) = length(optigraph.subgraphs)
 getsubgraph(optigraph::OptiGraph,idx::Int64) = optigraph.subgraphs[idx]
-
+subgraphs(optigraph::OptiGraph) = getsubgraphs(optigraph)
 """
     all_subgraphs(optigraph::OptiGraph)::Vector{OptiGraph}
 
@@ -185,7 +185,7 @@ end
 Retrieve the optinodes in `graph`.
 """
 getnodes(graph::OptiGraph) = graph.optinodes
-
+optinodes(graph::OptiGraph) = getnodes(graph)
 """
     getnode(graph::OptiGraph) = graph.optinodes
 
@@ -205,7 +205,7 @@ function all_nodes(graph::OptiGraph)
     end
     return nodes
 end
-
+all_optinodes(graph::OptiGraph) = all_nodes(graph)
 """
     all_node(graph::OptiGraph,index::Int64)
 
@@ -226,6 +226,13 @@ Retrieve the index of the optinode `node` in `graph`.
 function Base.getindex(graph::OptiGraph,node::OptiNode)
     return graph.node_idx_map[node]
 end
+
+"""
+    Base.getindex(graph::OptiGraph,index::Int64)
+
+Retrieve the node at `index` in `graph`.
+"""
+Base.getindex(graph::OptiGraph,index::Int64) = getnode(graph,index)
 
 ###################################################
 #OptiEdges
@@ -255,6 +262,7 @@ add_edge!(graph::OptiGraph,optinodes::Vector{OptiNode}) = add_optiedge!(graph,op
 Retrieve the local optiedges in `graph`.
 """
 getedges(graph::OptiGraph) = graph.optiedges
+optiedges(graph::OptiGraph) = getedges(graph)
 
 """
     getedge(graph::OptiGraph,index::Int64)
@@ -288,6 +296,7 @@ function all_edges(graph::OptiGraph)
     end
     return edges
 end
+all_optiedges(graph::OptiGraph) = all_edges(graph)
 
 function all_edge(graph::OptiGraph,index::Int64)
     edges = all_nodes(graph)
@@ -363,6 +372,7 @@ function getlinkconstraints(graph::OptiGraph)
     end
     return links
 end
+linkconstraints(graph::OptiGraph) = getlinkconstraints(graph)
 num_link_constraints(graph::OptiGraph) = sum(num_link_constraints.(graph.optiedges))
 @deprecate num_linkconstraints num_link_constraints
 """

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -5,7 +5,7 @@ struct OptiGraphOptimizeHook <: MOI.AbstractModelAttribute end
 JuMP.backend(graph::OptiGraph) = graph.optimizer
 JuMP.backend(node::OptiNode) = JuMP.backend(jump_model(node))
 JuMP.backend(edge::OptiEdge) = edge.backend
-JuMP.moi_mode(node_optimizer::NodeBackend) = JuMP.moi_mode(node_optimizer.optimizer)
+# JuMP.moi_mode(node_optimizer::NodeBackend) = JuMP.moi_mode(node_optimizer.optimizer)
 
 #Extend OptiNode and OptiGraph with MOI interface
 MOI.get(node::OptiNode, args...) = MOI.get(jump_model(node), args...)
@@ -20,7 +20,7 @@ function _aggregate_backends!(graph::OptiGraph)
     #Set node backends
     for node in all_nodes(graph)
         src = JuMP.backend(node)
-        idx_map = append_to_backend!(dest, src, false; filter_constraints=nothing)
+        idx_map = append_to_backend!(dest, src)
         node_pointer = NodePointer(dest,idx_map)
         src.optimizers[id] = node_pointer
         if !(id in src.graph_ids)
@@ -208,7 +208,7 @@ Set an MOI optimizer for the optigraph `graph`.
 function JuMP.set_optimizer(graph::OptiGraph, optimizer_constructor, bridge_constraints::Bool = true)
     backend = JuMP.backend(graph)
     if bridge_constraints
-        optimizer = MOI.instantiate(optimizer_constructor, with_bridge_type=Float64, with_names=false)
+        optimizer = MOI.instantiate(optimizer_constructor, with_bridge_type=Float64)
         for bridge_type in graph.bridge_types
             JuMP._moi_add_bridge(optimizer, bridge_type)
         end

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -288,6 +288,10 @@ function _moi_optimize!(graph::OptiGraph)
         end
     end
     _set_node_results!(graph)     #populate optimizer solutions onto each node backend
+    for node in all_nodes(graph)
+        jump_model(node).is_model_dirty = false
+    end
+    return nothing
 end
 
 function _create_nlp_block_data(graph::OptiGraph)
@@ -316,7 +320,7 @@ end
 #OptiGraph Optimizer Attributes
 #######################################################
 function JuMP.set_optimizer_attribute(graph::OptiGraph, name::String, value)
-    return JuMP.set_optimizer_attribute(graph, MOI.RawParameter(name), value)
+    return JuMP.set_optimizer_attribute(graph, MOI.RawOptimizerAttribute(name), value)
 end
 
 function JuMP.set_optimizer_attribute(
@@ -327,7 +331,7 @@ function JuMP.set_optimizer_attribute(
 end
 
 function JuMP.get_optimizer_attribute(graph::OptiGraph, name::String)
-    return JuMP.get_optimizer_attribute(graph, MOI.RawParameter(name))
+    return JuMP.get_optimizer_attribute(graph, MOI.RawOptimizerAttribute(name))
 end
 
 function JuMP.get_optimizer_attribute(

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -169,7 +169,7 @@ function _set_node_results!(graph::OptiGraph)
     end
 
     #edges (links)
-    #edges also point to Graph MOI model
+    #edges also point to graph backend model
     for linkref in all_linkconstraints(graph)
         edge = JuMP.owner_model(linkref)
         JuMP.backend(edge).last_solution_id = graph.id
@@ -203,9 +203,15 @@ JuMP.optimize!(graph::OptiGraph,optimizer;kwargs...) = error("The optimizer keyw
 """
     JuMP.set_optimizer(graph::OptiGraph,optimizer_constructor::Any)
 
-Set an MOI optimizer for the optigraph `graph`.
+Set an MOI optimizer onto the optigraph `graph`.  Works exactly the same as using JuMP to set an optimizer.
+
+## Examples
+```julia
+graph = OptiGraph()
+set_optimizer(graph, GLPK.Optimizer)
+```
 """
-function JuMP.set_optimizer(graph::OptiGraph, optimizer_constructor, bridge_constraints::Bool = true)
+function JuMP.set_optimizer(graph::OptiGraph, optimizer_constructor, bridge_constraints::Bool=true)
     backend = JuMP.backend(graph)
     if bridge_constraints
         optimizer = MOI.instantiate(optimizer_constructor, with_bridge_type=Float64)
@@ -219,43 +225,49 @@ function JuMP.set_optimizer(graph::OptiGraph, optimizer_constructor, bridge_cons
     return nothing
 end
 
-#Set an optigraph optimizer
-#TODO: drop this into a caching optimizer so we can pass attributes into it as needed
-# JuMP.set_optimizer(graph::OptiGraph, optimizer::OptiGraphOptimizer) = graph.optimizer=optimizer
+#Set an optigraph optimizer directly
+JuMP.set_optimizer(graph::OptiGraph, optimizer::MOI.ModelLike) = graph.optimizer=optimizer
 
 function JuMP.optimize!(graph::OptiGraph;kwargs...)
     graph_optimizer = JuMP.backend(graph)
+
     #NOTE: I think this will always be a MOIU.CachingOptimizer
     if isa(graph_optimizer,MOIU.CachingOptimizer)
         if MOIU.state(graph_optimizer) == MOIU.NO_OPTIMIZER
-            error("Please set an optimizer on optigraph before calling `optimize!` using `set_optimizer(graph,optimizer)`")
+            error("Please set an optimizer on the optigraph before calling `optimize!` by using `set_optimizer(graph,optimizer)`")
         end
     end
-
-    #check for optigraph optimize hook
-    try
-        #We have to attach the optimizer to query attributes
-        if !(MOIU.state(graph_optimizer) == MOIU.ATTACHED_OPTIMIZER)
-            MOIU.attach_optimizer(backend(graph))
-        end
-        optimize_func = MOI.get(graph_optimizer,MOIU.AttributeFromOptimizer(OptiGraphOptimizeHook()))
-        #TODO: Better checking for the model
-        optimize_func(graph,graph_optimizer.optimizer.model)
-    catch err
-        if !(typeof(err) in [KeyError,ArgumentError])
-            rethrow(err)
-        else  #otherwise, aggregate and solve with the MOI interface
-            _moi_optimize!(graph)
-        end
-    end
+    _aggregate_and_optimize!(graph)
+    #TODO: handle graph optimizers
+    # #check for optigraph optimize hook
+    # try
+    #     #We have to attach the optimizer to query attributes
+    #     if !(MOIU.state(graph_optimizer) == MOIU.ATTACHED_OPTIMIZER)
+    #         MOIU.attach_optimizer(backend(graph))
+    #     end
+    #     optimize_func = MOI.get(graph_optimizer,MOIU.AttributeFromOptimizer(OptiGraphOptimizeHook()))
+    #     #optimize_func(graph,graph_optimizer.optimizer.model)  #TODO: Better checking for the model
+    #
+    #     #MOI.optimize!(graph_optimizer)
+    #
+    #
+    # catch err
+    #     if !(typeof(err) in [KeyError,ArgumentError])
+    #         rethrow(err)
+    #     else  #otherwise, aggregate and solve with the MOI interface
+    #         _aggregate_and_optimize!(graph)
+    #     end
+    # end
     return nothing
 end
 
 #optimize with MOI interfaced optimizer
-function _moi_optimize!(graph::OptiGraph)
+function _aggregate_and_optimize!(graph::OptiGraph)
     #Build the MOI backend if it hasn't already been created
     if MOI.get(JuMP.backend(graph), MOI.TerminationStatus())==MOI.OPTIMIZE_NOT_CALLED
-        _aggregate_backends!(graph) #else, changes SHOULD have been captured
+        _aggregate_backends!(graph)
+    #else
+        #changes SHOULD have been captured (e.g. add_variable, add_constraint, etc...)
     end
 
     #set the optigraph objective if it is:
@@ -389,7 +401,3 @@ function set_node_status(node::OptiNode,status::MOI.TerminationStatusCode)
     node_backend = JuMP.backend(node)
     set_backend_status!(node_backend,status,node.id)
 end
-
-# caching_mode = MOIU.AUTOMATIC
-# universal_fallback = MOIU.UniversalFallback(MOIU.Model{Float64}())
-# backend = MOIU.CachingOptimizer(universal_fallback,caching_mode)

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -29,7 +29,7 @@ mutable struct OptiNode <: JuMP.AbstractModel
         "node",
         Dict{Int64,AbstractLinkConstraint}(),
         nothing,
-        DefaultDict{Symbol,OrderedDict}(OrderedDict()),
+        DefaultDict{Symbol,OrderedDict{Int64,Float64}}(OrderedDict()),
         Dict{Symbol,Any}(),
         id)
         node.model.ext[:optinode] = node

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -146,8 +146,8 @@ function Base.setindex!(node::OptiNode,value::Any,symbol::Symbol)
 end
 
 JuMP.object_dictionary(m::OptiNode) = m.model.obj_dict
-JuMP.variable_type(::OptiNode) = JuMP.VariableRef
-JuMP.constraint_type(::OptiNode) = JuMP.ConstraintRef
+# JuMP.variable_type(::OptiNode) = JuMP.VariableRef
+# JuMP.constraint_type(::OptiNode) = JuMP.ConstraintRef
 
 function JuMP.add_variable(node::OptiNode, v::JuMP.AbstractVariable, name::String="")
     jump_vref = JuMP.add_variable(node.model,v,name) #add the variable to the optinode
@@ -229,6 +229,7 @@ JuMP.primal_status(node::OptiNode) = JuMP.primal_status(jump_model(node))
 JuMP.dual_status(node::OptiNode) = JuMP.dual_status(jump_model(node))
 JuMP.solver_name(node::OptiNode) = JuMP.solver_name(jump_model(node))
 JuMP.mode(node::OptiNode) = JuMP.mode(jump_model(node))
+JuMP._moi_mode(node_backend::NodeBackend) = node_backend.optimizer.mode
 
 JuMP.list_of_constraint_types(node::OptiNode) = JuMP.list_of_constraint_types(jump_model(node))
 JuMP.all_constraints(node::OptiNode,F::DataType,S::DataType) = JuMP.all_constraints(jump_model(node),F,S)

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -118,6 +118,8 @@ function set_model(node::OptiNode,m::JuMP.AbstractModel;preserve_links = false)
     !(is_set_to_node(m) && jump_model(node) == m) || error("Model $m is already asigned to another node")
     node.model = m
     m.ext[:optinode] = node
+    node_backend = NodeBackend(JuMP.backend(m),node.id)
+    m.moi_backend = node_backend
 end
 @deprecate setmodel set_model
 
@@ -144,6 +146,7 @@ end
 function Base.setindex!(node::OptiNode,value::Any,symbol::Symbol)
     setattribute(node,symbol,value)
 end
+setlabel(node::OptiNode,label::Symbol) = node.label = label
 
 JuMP.object_dictionary(m::OptiNode) = m.model.obj_dict
 # JuMP.variable_type(::OptiNode) = JuMP.VariableRef

--- a/test/moi.jl
+++ b/test/moi.jl
@@ -29,8 +29,7 @@ function test_node_backend_1()
     @test MOI.supports_constraint(node_backend,MOI.ScalarAffineFunction{Float64},MOI.EqualTo{Float64})
 
     @test MOIU.state(node_backend) == MOIU.NO_OPTIMIZER
-    optimizer = Ipopt.Optimizer
-    set_optimizer(node,optimizer)
+    set_optimizer(node,Ipopt.Optimizer)
     @test MOIU.state(node_backend) == MOIU.EMPTY_OPTIMIZER
 
     MOIU.attach_optimizer(node_backend)
@@ -39,7 +38,7 @@ function test_node_backend_1()
     MOIU.drop_optimizer(node_backend)
     @test MOIU.state(node_backend) == MOIU.NO_OPTIMIZER
 
-    set_optimizer(node,optimizer)
+    set_optimizer(node,Ipopt.Optimizer)
     MOIU.attach_optimizer(node_backend)
     MOIU.reset_optimizer(node_backend,Ipopt.Optimizer())
     @test MOIU.state(node_backend) == MOIU.EMPTY_OPTIMIZER

--- a/test/moi.jl
+++ b/test/moi.jl
@@ -64,7 +64,7 @@ function test_set_solution()
     cons = Vector{MOI.ConstraintIndex}(undef,0)
     # cons = MOI.ConstraintIndex{F,S}[]
     cidx_duals = Float64[]
-    con_list = MOI.get(node_backend,MOI.ListOfConstraints())
+    con_list = MOI.get(node_backend,MOI.ListOfConstraintTypesPresent())
     for (F,S) in con_list
         cidx = MOI.get(node_backend,MOI.ListOfConstraintIndices{F,S}())
         append!(cons,cidx)

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -94,6 +94,10 @@ function test_set_model()
     @linkconstraint(graph,n1[:x] == n2[:x])
 
     @test num_variables(graph) == 3
+
+    set_optimizer(graph,Ipopt.Optimizer)
+    optimize!(graph)
+    @test termination_status(graph) == MOI.LOCALLY_SOLVED
 end
 
 function test_subgraph()
@@ -203,6 +207,7 @@ end
 #     for var in all_variables(graph)
 #         @test value(var) == 1.0
 #     end
+#     @test termination_status(graph) == MOI.OPTIMAL
 # end
 
 function run_tests()

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -95,7 +95,7 @@ function test_set_model()
 
     @test num_variables(graph) == 3
 
-    set_optimizer(graph,Ipopt.Optimizer)
+    set_optimizer(graph,optimizer_with_attributes(Ipopt.Optimizer,"print_level" => 0))
     optimize!(graph)
     @test termination_status(graph) == MOI.LOCALLY_SOLVED
 end

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -171,39 +171,39 @@ end
 
 # Test optigraph optimizer.  This is a way to set custom optimize calls on an optimizer
 # to make it work with an optigraph.
-mutable struct TestOptimizer <: MOI.AbstractOptimizer
-    status::MOI.TerminationStatusCode
-end
-TestOptimizer() = TestOptimizer(MOI.OPTIMIZE_NOT_CALLED)
-MOI.get(optimizer::TestOptimizer,::MOI.TerminationStatus) = optimizer.status
-MOI.get(optimizer::TestOptimizer,::Plasmo.OptiGraphOptimizeHook) = optigraph_optimize!
+# mutable struct TestOptimizer <: MOI.AbstractOptimizer
+#     status::MOI.TerminationStatusCode
+# end
+# TestOptimizer() = TestOptimizer(MOI.OPTIMIZE_NOT_CALLED)
+# MOI.get(optimizer::TestOptimizer,::MOI.TerminationStatus) = optimizer.status
+# MOI.get(optimizer::TestOptimizer,::Plasmo.OptiGraphOptimizeHook) = optigraph_optimize!
+#
+# MOI.is_empty(::TestOptimizer) = true
+# MOI.empty!(::TestOptimizer) = nothing
+# MOI.copy_to(dest::TestOptimizer,src::MOI.ModelLike;kwargs...) = MOIU.default_copy_to(dest,src;kwargs...)
+# MOIU.supports_default_copy_to(model::TestOptimizer, copy_names::Bool) = true
 
-MOI.is_empty(::TestOptimizer) = true
-MOI.empty!(::TestOptimizer) = nothing
-MOI.copy_to(dest::TestOptimizer,src::MOI.ModelLike;kwargs...) = MOIU.default_copy_to(dest,src;kwargs...)
-MOIU.supports_default_copy_to(model::TestOptimizer, copy_names::Bool) = true
+# function optigraph_optimize!(graph::OptiGraph,optimizer::TestOptimizer)
+#     println("Running Test Optimizer")
+#     for node in all_nodes(graph)
+#         vars = all_variables(node)
+#         vals = ones(length(vars))
+#         Plasmo.set_node_primals(node,vars,vals)
+#         Plasmo.set_node_status(node,MOI.OPTIMAL)
+#     end
+#     optimizer.status = MOI.OPTIMAL
+#     return nothing
+# end
 
-function optigraph_optimize!(graph::OptiGraph,optimizer::TestOptimizer)
-    println("Running Test Optimizer")
-    for node in all_nodes(graph)
-        vars = all_variables(node)
-        vals = ones(length(vars))
-        Plasmo.set_node_primals(node,vars,vals)
-        Plasmo.set_node_status(node,MOI.OPTIMAL)
-    end
-    optimizer.status = MOI.OPTIMAL
-    return nothing
-end
-
-function test_optigraph_optimizer()
-    graph = _create_optigraph()
-    test_optimizer = TestOptimizer
-    set_optimizer(graph,test_optimizer)
-    Plasmo.optimize!(graph)
-    for var in all_variables(graph)
-        @test value(var) == 1.0
-    end
-end
+# function test_optigraph_optimizer()
+#     graph = _create_optigraph()
+#     test_optimizer = TestOptimizer
+#     set_optimizer(graph,test_optimizer)
+#     Plasmo.optimize!(graph)
+#     for var in all_variables(graph)
+#         @test value(var) == 1.0
+#     end
+# end
 
 function run_tests()
     for name in names(@__MODULE__; all = true)

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -136,7 +136,7 @@ end
 function test_multiple_solves()
     graph = _create_optigraph()
     n1 = getnode(graph,1)
-    set_optimizer(graph,Ipopt.Optimizer)
+    set_optimizer(graph,optimizer_with_attributes(Ipopt.Optimizer,"print_level" => 0))
     optimize!(graph)
     @test isapprox(value(n1[:x]),0,atol = 1e-6)
 
@@ -149,7 +149,7 @@ function test_fix_variable()
     graph = _create_optigraph()
     n1 = getnode(graph,1)
     fix(n1[:x],1,force = true)
-    set_optimizer(graph,Ipopt.Optimizer)
+    set_optimizer(graph,optimizer_with_attributes(Ipopt.Optimizer,"print_level" => 0))
     optimize!(graph)
     @test value(n1[:x]) == 1
 
@@ -164,7 +164,7 @@ end
 
 function test_set_optimizer_attributes()
     graph = _create_optigraph()
-    set_optimizer(graph,Ipopt.Optimizer)
+    set_optimizer(graph,optimizer_with_attributes(Ipopt.Optimizer,"print_level" => 0))
     JuMP.set_optimizer_attribute(graph,"max_cpu_time",1e2)
     @test JuMP.get_optimizer_attribute(graph,"max_cpu_time") == 100.0
 end


### PR DESCRIPTION
This PR updates Plasmo.jl to work with JuMP v0.22. Otherwise, there are no API changes.