### PR TITLE
Fix nlp variable order

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -2,7 +2,7 @@ name = "Plasmo"
 uuid = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"
 authors = ["Jordan Jalving <jhjalving@gmail.com>"]
 repo = "https://github.com/zavalab/Plasmo.jl.git"
-version = "0.4.3"
+version = "0.4.4"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"

--- a/src/moi.jl
+++ b/src/moi.jl
@@ -268,20 +268,23 @@ function append_to_backend!(dest::MOI.ModelLike, src::MOI.ModelLike)
     # per the comment in MOI:
     # "The `NLPBlock` assumes that the order of variables does not change (#849)
     # Therefore, all VariableIndex and VectorOfVariable constraints are added
-    # seprately, and no variables constrained-on-creation are added.
-    has_nlp = MOI.NLPBlock() in MOI.get(src, MOI.ListOfModelAttributesSet())
-    constraints_not_added = if has_nlp
-        Any[
+    # seprately, and no variables constrained-on-creation are added.""
+    # Consequently, Plasmo avoids using the constrained-on-creation approach because
+    # of the way it constructs the NLPBlock for the optimizer.
+    
+    # has_nlp = MOI.NLPBlock() in MOI.get(src, MOI.ListOfModelAttributesSet())
+    # constraints_not_added = if has_nlp
+    constraints_not_added = Any[
             MOI.get(src, MOI.ListOfConstraintIndices{F,S}()) for
             (F, S) in MOI.get(src, MOI.ListOfConstraintTypesPresent()) if
             MOIU._is_variable_function(F)
         ]
-    else
-        Any[
-            MOIU._try_constrain_variables_on_creation(dest, src, index_map, S)
-            for S in MOIU.sorted_variable_sets_by_cost(dest, src)
-        ]
-    end
+    # else
+    #     Any[
+    #         MOIU._try_constrain_variables_on_creation(dest, src, index_map, S)
+    #         for S in MOIU.sorted_variable_sets_by_cost(dest, src)
+    #     ]
+    # end
 
     #Copy free variables into graph optimizer
     MOI.Utilities._copy_free_variables(dest, index_map, vis_src)


### PR DESCRIPTION
This should fix an issue that @etatara was seeing with incorrect hessian-lagrangian and jacobian structures. The issue had to do with the constrained-on-creation approach that MOI uses to copy models which was leading to an incorrect variable order in an Ipopt model.  Now we just always keep the variables in order due to the way Plasmo.jl has to construct the NLPBlock.