### PR TITLE
Fix slow graph objective

### DIFF
--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -637,43 +637,56 @@ Set a quadratic objective function on optigraph `graph`
 function JuMP.set_objective_function(graph::OptiGraph, x::JuMP.VariableRef)
     x_affine = convert(JuMP.AffExpr, x)
     return JuMP.set_objective_function(graph, x_affine)
-    #_moi_update_objective() #update the optigraph backend if we're doing incremental solves
 end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericAffExpr)
-    #clear optinodes objective functions
-    # node_expressions = Dict()
-    # for node in all_nodes(graph)
-    #     node_expressions[node] = JuMP.AffExpr()
-    # end
-    # for (coef, term) in JuMP.linear_terms(expr)
-    #     node = optinode(term)
-    #     JuMP.add_to_expression!(node_expressions[node], coef, term)
-    # end
-    # for node in all_nodes(graph)
-    #     JuMP.set_objective_function(node, node_expressions[node])
-    # end
-    return graph.objective_function = expr
+    graph.objective_function = expr
+    return
 end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericQuadExpr)
-    # node_expressions = Dict()
-    # for node in all_nodes(graph)
-    #     node_expressions[node] = JuMP.QuadExpr()
-    # end
-    # for (coef, term1, term2) in JuMP.quad_terms(expr)
-    #     @assert optinode(term1) == optinode(term2)
-    #     node = optinode(term1)
-    #     JuMP.add_to_expression!(node_expressions[node], coef, term1, term2)
-    # end
-    # for (coef, term) in JuMP.linear_terms(expr)
-    #     node = optinode(term)
-    #     JuMP.add_to_expression!(node_expressions[node], coef, term)
-    # end
-    # for node in all_nodes(graph)
-    #     JuMP.set_objective_function(node, node_expressions[node])
-    # end
-    return graph.objective_function = expr
+    graph.objective_function = expr
+    return
+end
+
+function set_node_objective_functions(graph::OptiGraph)
+    _set_node_objective_functions(graph, objective_function(graph))
+    return
+end
+
+function _set_node_objective_functions(graph::OptiGraph, expr::JuMP.GenericAffExpr)
+    node_expressions = Dict()
+    for node in all_nodes(graph)
+        node_expressions[node] = JuMP.AffExpr()
+    end
+    for (coef, term) in JuMP.linear_terms(expr)
+        node = optinode(term)
+        JuMP.add_to_expression!(node_expressions[node], coef, term)
+    end
+    for node in all_nodes(graph)
+        JuMP.set_objective_function(node, node_expressions[node])
+    end
+    return
+end
+
+function _set_node_objective_functions(graph::OptiGraph, expr::JuMP.GenericQuadExpr)
+    node_expressions = Dict()
+    for node in all_nodes(graph)
+        node_expressions[node] = JuMP.QuadExpr()
+    end
+    for (coef, term1, term2) in JuMP.quad_terms(expr)
+        @assert optinode(term1) == optinode(term2)
+        node = optinode(term1)
+        JuMP.add_to_expression!(node_expressions[node], coef, term1, term2)
+    end
+    for (coef, term) in JuMP.linear_terms(expr)
+        node = optinode(term)
+        JuMP.add_to_expression!(node_expressions[node], coef, term)
+    end
+    for node in all_nodes(graph)
+        JuMP.set_objective_function(node, node_expressions[node])
+    end
+    return
 end
 
 """

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -642,29 +642,36 @@ end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericAffExpr)
     #clear optinodes objective functions
+    node_expressions = Dict()
     for node in all_nodes(graph)
-        JuMP.set_objective_function(node, JuMP.AffExpr())
+        node_expressions[node] = JuMP.AffExpr()
     end
-    #put objective terms onto nodes
     for (coef, term) in JuMP.linear_terms(expr)
         node = optinode(term)
-        JuMP.set_objective_function(node,JuMP.add_to_expression!(objective_function(node), coef, term))
+        JuMP.add_to_expression!(node_expressions[node], coef, term)
+    end
+    for node in all_nodes(graph)
+        JuMP.set_objective_function(node, node_expressions[node])
     end
     return graph.objective_function = expr
 end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericQuadExpr)
+    node_expressions = Dict()
     for node in all_nodes(graph)
-        JuMP.set_objective_function(node, JuMP.QuadExpr())
+        node_expressions[node] = JuMP.QuadExpr()
     end
     for (coef, term1, term2) in JuMP.quad_terms(expr)
         @assert optinode(term1) == optinode(term2)
         node = optinode(term1)
-        JuMP.set_objective_function(node,JuMP.add_to_expression!(objective_function(node), coef, term1, term2))
+        JuMP.add_to_expression!(node_expressions[node], coef, term1, term2)
     end
     for (coef, term) in JuMP.linear_terms(expr)
         node = optinode(term)
-        JuMP.set_objective_function(node,JuMP.add_to_expression!(objective_function(node), coef, term))
+        JuMP.add_to_expression!(node_expressions[node], coef, term)
+    end
+    for node in all_nodes(graph)
+        JuMP.set_objective_function(node, node_expressions[node])
     end
     return graph.objective_function = expr
 end

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -642,37 +642,37 @@ end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericAffExpr)
     #clear optinodes objective functions
-    node_expressions = Dict()
-    for node in all_nodes(graph)
-        node_expressions[node] = JuMP.AffExpr()
-    end
-    for (coef, term) in JuMP.linear_terms(expr)
-        node = optinode(term)
-        JuMP.add_to_expression!(node_expressions[node], coef, term)
-    end
-    for node in all_nodes(graph)
-        JuMP.set_objective_function(node, node_expressions[node])
-    end
+    # node_expressions = Dict()
+    # for node in all_nodes(graph)
+    #     node_expressions[node] = JuMP.AffExpr()
+    # end
+    # for (coef, term) in JuMP.linear_terms(expr)
+    #     node = optinode(term)
+    #     JuMP.add_to_expression!(node_expressions[node], coef, term)
+    # end
+    # for node in all_nodes(graph)
+    #     JuMP.set_objective_function(node, node_expressions[node])
+    # end
     return graph.objective_function = expr
 end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericQuadExpr)
-    node_expressions = Dict()
-    for node in all_nodes(graph)
-        node_expressions[node] = JuMP.QuadExpr()
-    end
-    for (coef, term1, term2) in JuMP.quad_terms(expr)
-        @assert optinode(term1) == optinode(term2)
-        node = optinode(term1)
-        JuMP.add_to_expression!(node_expressions[node], coef, term1, term2)
-    end
-    for (coef, term) in JuMP.linear_terms(expr)
-        node = optinode(term)
-        JuMP.add_to_expression!(node_expressions[node], coef, term)
-    end
-    for node in all_nodes(graph)
-        JuMP.set_objective_function(node, node_expressions[node])
-    end
+    # node_expressions = Dict()
+    # for node in all_nodes(graph)
+    #     node_expressions[node] = JuMP.QuadExpr()
+    # end
+    # for (coef, term1, term2) in JuMP.quad_terms(expr)
+    #     @assert optinode(term1) == optinode(term2)
+    #     node = optinode(term1)
+    #     JuMP.add_to_expression!(node_expressions[node], coef, term1, term2)
+    # end
+    # for (coef, term) in JuMP.linear_terms(expr)
+    #     node = optinode(term)
+    #     JuMP.add_to_expression!(node_expressions[node], coef, term)
+    # end
+    # for node in all_nodes(graph)
+    #     JuMP.set_objective_function(node, node_expressions[node])
+    # end
     return graph.objective_function = expr
 end
 

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -9,11 +9,12 @@ MOI.get(node::OptiNode, args...) = MOI.get(jump_model(node), args...)
 MOI.set(node::OptiNode, args...) = MOI.set(jump_model(node), args...)
 MOI.get(graph::OptiGraph, args...) = MOI.get(JuMP.backend(graph), args...)
 
-#Set the optigraph objective to the sume of the nodes
+#Set the optigraph objective to the sum of the nodes
 function _set_graph_objective(graph::OptiGraph)
     if !has_objective(graph) && has_node_objective(graph)
         nodes = all_nodes(graph)
         for node in nodes
+            # TODO: do not modify the nodes
             if JuMP.objective_sense(node) == MOI.MAX_SENSE
                 JuMP.set_objective_sense(node, MOI.MIN_SENSE)
                 JuMP.set_objective_function(node, -1 * JuMP.objective_function(node))

--- a/test/moi_node.jl
+++ b/test/moi_node.jl
@@ -126,6 +126,7 @@ function test_multiple_graph_changes()
     optimize!(graph)
 
     sub = Plasmo.induced_subgraph(graph, nodes[1:2])
+    @objective(sub, Min, sum(node[:x] for node in all_nodes(sub)))
     set_optimizer(sub, optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0))
     optimize!(sub)
 

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -85,7 +85,7 @@ function test_optigraph2()
     @test Plasmo.has_nlp_data(graph) == true
     @test Plasmo.has_objective(graph) == true
     @test Plasmo.has_nl_objective(graph) == false
-    @test Plasmo.has_node_objective(graph) == true
+    @test Plasmo.has_node_objective(graph) == false
 
     #test quadratic objective
     @objective(graph, Min, graph[1][:x]^2 + graph[2][:x]^2 + graph[4][:x])


### PR DESCRIPTION
This fixes a recurring issue that PR https://github.com/plasmo-dev/Plasmo.jl/pull/78 was supposed to address. The problem is that even using `add_to_expression!` is still very slow when updating node objective functions using the graph objective. The solution used here is to simply separate node and graph objective functions. A user must actually call `set_node_objective_functions` if they intend to update all of the nodes with a graph objective.