### PR TITLE
Fix printing tests for JuMP v1.11.1

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -19,12 +19,16 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 DataStructures = "0.18"
-LightGraphs = "~1.3"
+GLPK = "1"
+JuMP = "1.11.1"
+Ipopt = "1"
+KaHyPar = "0.3"
+LightGraphs = "1.3"
 MathOptInterface = "1.6"
-JuMP = "1.2"
-Reexport = "~0.2, 1"
-Requires = "~1.0, 1"
-julia = "1"
+Reexport = "0.2, 1"
+Requires = "1"
+Suppressor = "0.2"
+julia = "1.6"
 
 [extras]
 GLPK = "60bf3e95-4087-53dc-ae20-288a0d20c6a6"
@@ -34,4 +38,4 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test", "Suppressor", "Ipopt", "GLPK", "KaHyPar"]
+test = ["GLPK", "Ipopt", "KaHyPar", "Suppressor", "Test"]

--- a/test/optiedge.jl
+++ b/test/optiedge.jl
@@ -58,8 +58,8 @@ function test_optiedge_1()
 
     @test Base.string(e1) == "OptiEdge w/ 1 Constraint(s)"
     @test JuMP.constraint_string(MIME("text/latex"), link_ref) ==
-        "ref: n4[:x] - n1[:x] = 0.0"
-    @test JuMP.constraint_string(MIME("text/latex"), link_con) == "n4_{:x} - n1_{:x} = 0.0"
+        "ref: n4[:x] - n1[:x] = 0"
+    @test JuMP.constraint_string(MIME("text/latex"), link_con) == "n4_{:x} - n1_{:x} = 0"
     @test Base.string(link_con) ==
         "LinkConstraint: n4[:x] - n1[:x], MathOptInterface.EqualTo{Float64}(0.0)"
 


### PR DESCRIPTION
JuMP recently tweaked how we printed sets: https://github.com/jump-dev/JuMP.jl/pull/3341.

I also took the liberty of adding compat bounds for your test dependencies.