### PR TITLE
Updated `dual(subgraph, linkconstraint)` to call from correct subgraph

### DIFF
--- a/src/optiedge.jl
+++ b/src/optiedge.jl
@@ -118,10 +118,9 @@ function JuMP.constraint_object(linkref::LinkConstraintRef)
     return linkref.optiedge.linkconstraints[linkref.idx]
 end
 
-#TODO: Update this
 function JuMP.dual(linkref::LinkConstraintRef)
     optiedge = JuMP.owner_model(linkref)
-    id = optiedge.backend.last_solution_id
+    # this grabs the last solution
     return MOI.get(optiedge.backend, MOI.ConstraintDual(), linkref)
 end
 

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -889,14 +889,8 @@ Retrieve the dual value of `linkref` on optigraph `graph`.
 """
 function JuMP.dual(graph::OptiGraph, linkref::LinkConstraintRef)
     optiedge = JuMP.owner_model(linkref)
-    id = graph.id
-
-    last_solution_id = optiedge.backend.last_solution_id
-    optiedge.backend.last_solution_id = graph_id
-
+    edge_pointer = optiedge.backend.optimizers[graph.id]
     dual_value = MOI.get(optiedge.backend, MOI.ConstraintDual(), linkref)
-    optiedge.backend.last_solution_id = last_solution_id
-
     return dual_value
 end
 

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -890,7 +890,14 @@ Retrieve the dual value of `linkref` on optigraph `graph`.
 function JuMP.dual(graph::OptiGraph, linkref::LinkConstraintRef)
     optiedge = JuMP.owner_model(linkref)
     id = graph.id
-    return MOI.get(optiedge.backend, MOI.ConstraintDual(), linkref)
+
+    last_solution_id = optiedge.backend.last_solution_id
+    optiedge.backend.last_solution_id = graph_id
+
+    dual_value = MOI.get(optiedge.backend, MOI.ConstraintDual(), linkref)
+    optiedge.backend.last_solution_id = last_solution_id
+
+    return dual_value
 end
 
 # set start value for a graph backend


### PR DESCRIPTION
This is meant to address #86 where `dual(subgraph, linkconstraint)` does not always use the `subgraph` graph id to get the dual value of a link constraint. Instead, it always calls the `linkconstraint`'s last solution id. 