### PR TITLE
fix multiple graph dual

### DIFF
--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -890,7 +890,7 @@ Retrieve the dual value of `linkref` on optigraph `graph`.
 function JuMP.dual(graph::OptiGraph, linkref::LinkConstraintRef)
     optiedge = JuMP.owner_model(linkref)
     edge_pointer = optiedge.backend.optimizers[graph.id]
-    dual_value = MOI.get(optiedge.backend, MOI.ConstraintDual(), linkref)
+    dual_value = MOI.get(edge_pointer, MOI.ConstraintDual(), linkref)
     return dual_value
 end
 


### PR DESCRIPTION
I missed a line in PR #90 such that that retrieving dual information was still incorrect. This should fix the issue. This PR additionally adds a test for retrieving duals on linkconstraints that exist in multiple optigraphs.

This should fix Issue #86 