### PR TITLE
support reset optimizer for optigraph

### DIFF
--- a/examples/optigraph_2_nodes.jl
+++ b/examples/optigraph_2_nodes.jl
@@ -8,26 +8,26 @@ n1 = @optinode(graph)
 n2 = @optinode(graph)
 
 #Node 1 Model
-@variable(n1,0 <= x <= 2)
-@variable(n1,0 <= y <= 3)
+@variable(n1, 0 <= x <= 2)
+@variable(n1, 0 <= y <= 3)
 @variable(n1, z >= 0)
-@constraint(n1,x+y+z >= 4)
+@constraint(n1, x + y + z >= 4)
 
 #Node 2 Model
-@variable(n2,x)
-@variable(n2,z >= 0)
-@constraint(n2,z + x >= 4)
+@variable(n2, x)
+@variable(n2, z >= 0)
+@constraint(n2, z + x >= 4)
 
 #Link constraints take the same expressions as the JuMP @constraint macro
-@linkconstraint(graph,n1[:x] == n2[:x])
-@linkconstraint(graph,n1[:z] == n2[:z])
+@linkconstraint(graph, n1[:x] == n2[:x])
+@linkconstraint(graph, n1[:z] == n2[:z])
 
 #Objective function
-@objective(graph,Min,n1[:y] + n2[:x] + n1[:z])
+@objective(graph, Min, n1[:y] + n2[:x] + n1[:z])
 
 #Optimize with glpk.
 optimizer = GLPK.Optimizer
-set_optimizer(graph,optimizer)
+set_optimizer(graph, optimizer)
 optimize!(graph)
 
 #Get results
@@ -36,16 +36,16 @@ println("objective value = ", objective_value(graph))
 
 println()
 println("variable values:")
-println("n1[:z] = ",value(n1[:z]))
-println("n2[:z] = ",value(n2[:z]))
-println("n1[:x] = ",value(n1[:x]))
-println("n1[:y] = ",value(n1[:y]))
-println("n2[:x] = ",value(n2[:x]))
+println("n1[:z] = ", value(n1[:z]))
+println("n2[:z] = ", value(n2[:z]))
+println("n1[:x] = ", value(n1[:x]))
+println("n1[:y] = ", value(n1[:y]))
+println("n2[:x] = ", value(n2[:x]))
 
 println()
 println("dual values on nodes:")
 for constraint_type in list_of_constraint_types(graph)
-    cons = all_constraints(graph,constraint_type[1],constraint_type[2])
+    cons = all_constraints(graph, constraint_type[1], constraint_type[2])
     for con in cons
         println("($con) = $(dual(con))")
     end

--- a/src/Plasmo.jl
+++ b/src/Plasmo.jl
@@ -89,7 +89,6 @@ export
     hierarchical_edges_not_global,
     global_edges,
     graph_depth,
-
     aggregate,
     aggregate!,
 

--- a/src/moi_backend_graph.jl
+++ b/src/moi_backend_graph.jl
@@ -273,3 +273,16 @@ function MOI.optimize!(graph_backend::GraphBackend)
     MOI.optimize!(graph_backend.optimizer)
     return nothing
 end
+
+function MOIU.reset_optimizer(graph_backend::GraphBackend)
+    MOI.empty!(graph_backend.optimizer)
+    # delete graph backend from all nodes
+    graph = graph_backend.optigraph
+    for node in all_nodes(graph_backend.optigraph)
+        nb = JuMP.backend(node)
+        filter!(x -> x != graph.id, nb.graph_ids)
+        delete!(nb.optimizers, graph.id)
+    end
+    graph_backend.state = MOIU.EMPTY_OPTIMIZER
+    return nothing
+end

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -642,17 +642,17 @@ end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericAffExpr)
     graph.objective_function = expr
-    return
+    return nothing
 end
 
 function JuMP.set_objective_function(graph::OptiGraph, expr::JuMP.GenericQuadExpr)
     graph.objective_function = expr
-    return
+    return nothing
 end
 
 function set_node_objective_functions(graph::OptiGraph)
     _set_node_objective_functions(graph, objective_function(graph))
-    return
+    return nothing
 end
 
 function _set_node_objective_functions(graph::OptiGraph, expr::JuMP.GenericAffExpr)
@@ -667,7 +667,7 @@ function _set_node_objective_functions(graph::OptiGraph, expr::JuMP.GenericAffEx
     for node in all_nodes(graph)
         JuMP.set_objective_function(node, node_expressions[node])
     end
-    return
+    return nothing
 end
 
 function _set_node_objective_functions(graph::OptiGraph, expr::JuMP.GenericQuadExpr)
@@ -687,7 +687,7 @@ function _set_node_objective_functions(graph::OptiGraph, expr::JuMP.GenericQuadE
     for node in all_nodes(graph)
         JuMP.set_objective_function(node, node_expressions[node])
     end
-    return
+    return nothing
 end
 
 """

--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -175,6 +175,10 @@ function MOIU.attach_optimizer(graph::OptiGraph)
     return MOIU.attach_optimizer(backend(graph))
 end
 
+function MOIU.reset_optimizer(graph::OptiGraph)
+    return MOIU.reset_optimizer(backend(graph))
+end
+
 #################################
 # Optimizer
 #################################

--- a/test/optiedge.jl
+++ b/test/optiedge.jl
@@ -57,8 +57,7 @@ function test_optiedge_1()
     @test num_nodes(link_con) == 2
 
     @test Base.string(e1) == "OptiEdge w/ 1 Constraint(s)"
-    @test JuMP.constraint_string(MIME("text/latex"), link_ref) ==
-        "ref: n4[:x] - n1[:x] = 0"
+    @test JuMP.constraint_string(MIME("text/latex"), link_ref) == "ref: n4[:x] - n1[:x] = 0"
     @test JuMP.constraint_string(MIME("text/latex"), link_con) == "n4_{:x} - n1_{:x} = 0"
     @test Base.string(link_con) ==
         "LinkConstraint: n4[:x] - n1[:x], MathOptInterface.EqualTo{Float64}(0.0)"

--- a/test/optigraph.jl
+++ b/test/optigraph.jl
@@ -284,12 +284,12 @@ function test_multiple_graphs()
     expanded_subgraphs = Plasmo.expand.(graph, subs, 1)
 
     set_optimizer(
-        expanded_subgraphs[1], 
-        optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
+        expanded_subgraphs[1],
+        optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0),
     )
     set_optimizer(
-        expanded_subgraphs[2], 
-        optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0)
+        expanded_subgraphs[2],
+        optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0),
     )
 
     middle_link = graph.optiedges[1].linkrefs[1]


### PR DESCRIPTION
This PR provides a workaround for issue #87. Sometimes modifying an optigraph fails after a solve if the attached optimizer does not support an incremental update. If needed, a user can call `reset_optimizer(graph` to reset the optimizer before making changes. Eventually, we should do this automatically by checking whether a modification is supported. 