### PR TITLE
fix: :bug: Return functions to undo relax_integrality

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -383,9 +383,8 @@ function JuMP.optimize!(node::OptiNode; kwargs...)
 end
 
 function JuMP.relax_integrality(graph::OptiGraph)
-    for node in all_nodes(graph)
-        JuMP.relax_integrality(jump_model(node))
-    end
+    # Returns vector of functions to revert the relaxation. Call via map(x->x()).
+    return [JuMP.relax_integrality(jump_model(node)) for node in all_nodes(graph)]
 end
 
 function set_node_primals(


### PR DESCRIPTION
Returns function vector to undo a relaxation operation. Example: https://jump.dev/JuMP.jl/stable/manual/models/#Relax-integrality