### PR TITLE
Added get and set optimizer attribute for nodes

### DIFF
--- a/src/optimizer_interface.jl
+++ b/src/optimizer_interface.jl
@@ -329,6 +329,16 @@ function JuMP.set_optimizer_attribute(
     return MOI.set(graph, attr, value)
 end
 
+function JuMP.set_optimizer_attribute(node::OptiNode, name::String, value)
+    return JuMP.set_optimizer_attribute(node, MOI.RawOptimizerAttribute(name), value)
+end
+
+function JuMP.set_optimizer_attribute(
+    node::OptiNode, attr::MOI.AbstractOptimizerAttribute, value
+)
+    return MOI.set(node, attr, value)
+end
+
 function JuMP.get_optimizer_attribute(graph::OptiGraph, name::String)
     return JuMP.get_optimizer_attribute(graph, MOI.RawOptimizerAttribute(name))
 end
@@ -337,6 +347,16 @@ function JuMP.get_optimizer_attribute(
     graph::OptiGraph, attr::MOI.AbstractOptimizerAttribute
 )
     return MOI.get(graph, attr)
+end
+
+function JuMP.get_optimizer_attribute(node::OptiNode, name::String)
+    return JuMP.get_optimizer_attribute(node, MOI.RawOptimizerAttribute(name))
+end
+
+function JuMP.get_optimizer_attribute(
+    node::OptiNode, attr::MOI.AbstractOptimizerAttribute
+)
+    return MOI.get(node, attr)
 end
 
 function MOI.get(graph::OptiGraph, attr::MOI.AbstractOptimizerAttribute)

--- a/test/optinode.jl
+++ b/test/optinode.jl
@@ -141,6 +141,14 @@ function test_optinode_set_solution()
     @test JuMP.termination_status(n1) == MOI.OPTIMAL
 end
 
+function test_optinode_set_optimizer_attributes()
+    graph = OptiGraph()
+    n1 = add_node!(graph)
+    set_optimizer(n1, optimizer_with_attributes(Ipopt.Optimizer, "print_level" => 0))
+    JuMP.set_optimizer_attribute(n1, "max_cpu_time", 1e2)
+    @test JuMP.get_optimizer_attribute(n1, "max_cpu_time") == 100.0
+end
+
 function run_tests()
     for name in names(@__MODULE__; all=true)
         if !startswith("$(name)", "test_")


### PR DESCRIPTION
Extended the `get_optimizer_attribute` and `set_optimizer_attribute` functions to work for OptiNodes and added tests for testing these functions. Currently, these functions are not implemented for OptiNodes, only for OptiGraphs.