### PR TITLE
Fixed bug in `incidence_matrix(hypergraph)` when graph is not fully connected

### DIFF
--- a/src/graph_representations/hypergraph.jl
+++ b/src/graph_representations/hypergraph.jl
@@ -128,7 +128,9 @@ function LightGraphs.incidence_matrix(hypergraph::HyperGraph)
         end
     end
     V = Int.(ones(length(I)))
-    return SparseArrays.sparse(I, J, V)
+    m = length(hypergraph.vertices)
+    n = m
+    return SparseArrays.sparse(I, J, V, m, n)
 end
 
 """

--- a/src/graph_representations/hypergraph.jl
+++ b/src/graph_representations/hypergraph.jl
@@ -129,7 +129,7 @@ function LightGraphs.incidence_matrix(hypergraph::HyperGraph)
     end
     V = Int.(ones(length(I)))
     m = length(hypergraph.vertices)
-    n = m
+    n = length(hypergraph.hyperedge_map)
     return SparseArrays.sparse(I, J, V, m, n)
 end
 


### PR DESCRIPTION
I found that if I have a graph with nodes that are not fully connected, calling `incident_edges(graph, nodes::Vector{OptiNode})` returns an error because of a dimension mismatch [here](https://github.com/plasmo-dev/Plasmo.jl/blob/4e29c2267b171b5ef1e2eda5efdc2e0bbea92c4a/src/graph_representations/hypergraph.jl#L192-L194). It looks like this happens because the extension of `LightGraphs.incidence_matrix(hypergraph)` does not set a dimension when calling `SparseArrays.sparse`. This PR fixes that by setting the dimension of the sparse matrix. 