### PR TITLE
Fix minor bug in aggregate

### DIFF
--- a/src/aggregate.jl
+++ b/src/aggregate.jl
@@ -83,6 +83,17 @@ function aggregate(graph::OptiGraph; name=gensym())
     # setup index_map from the ref_map
     _copy_attributes_to!(new_graph, graph, ref_map)
 
+    if iszero(objective_function(graph))
+        if has_node_objective(graph)
+            @warn """
+            The optigraph objective is empty, but objectives exist on optinodes. 
+            The aggregated graph copies the optigraph objective ONLY (not optinodes).
+            If this is not intended, consider using `set_to_node_objectives(graph)` to 
+            set the graph objective function before calling `aggregate`. 
+            """
+        end
+    end
+
     # TODO: make sure we are correctly copying objective function to node
     JuMP.set_objective(new_node, objective_sense(new_graph), objective_function(new_graph))
     return new_node, ref_map
@@ -126,8 +137,8 @@ function _copy_attributes_to!(
     dest = graph_backend(new_graph)
     index_map = MOIU.IndexMap()
 
-    # NOTE: we use an if statement because the source graph does not necessarily have all 
-    # the variables or constraints. we just want to pass the attributes that would be 
+    # NOTE: we use an if statement because the source graph does not necessarily have all
+    # the variables or constraints. we just want to pass the attributes that would be
     # exposed such as the graph objective function.
     for (source_vref, dest_vref) in ref_map.var_map
         # TODO: use outer method here; don't access data members directly
@@ -444,7 +455,7 @@ function aggregate_to_depth(graph::OptiGraph, max_depth::Int64=0; name=gensym())
         # copy optiedges
         for edge in edges
             _copy_edge_to!(new_graph, edge, ref_map)
-            # new_edge, edge_ref_map = 
+            # new_edge, edge_ref_map =
             # ref_map[edge] = new_edge
         end
     end

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -218,8 +218,7 @@ function JuMP.set_objective(
     node::OptiNode, sense::MOI.OptimizationSense, func::JuMP.AbstractJuMPScalar
 )
     # check that all func terms are for this node
-    node_set = unique(collect_nodes(func))
-    (node_set == [node] || length(node_set) == 0) || error("Optinode does not own all variables.")
+    (unique(collect_nodes(func)) == [node] || func == 0) || error("Optinode does not own all variables.")
     d = JuMP.object_dictionary(node)
     d[(node, :objective_sense)] = sense
     d[(node, :objective_function)] = func
@@ -228,8 +227,7 @@ end
 
 function JuMP.set_objective_function(node::OptiNode, func::JuMP.AbstractJuMPScalar)
     # check that all func terms are for this node
-    node_set = unique(collect_nodes(func))
-    (node_set == [node] || length(node_set) == 0) || error("Optinode does not own all variables.")
+    (unique(collect_nodes(func)) == [node] || func == 0) || error("Optinode does not own all variables.")
     d = JuMP.object_dictionary(node)
     d[(node, :objective_function)] = func
     return nothing

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -218,7 +218,8 @@ function JuMP.set_objective(
     node::OptiNode, sense::MOI.OptimizationSense, func::JuMP.AbstractJuMPScalar
 )
     # check that all func terms are for this node
-    unique(collect_nodes(func)) == [node] || error("Optinode does not own all variables.")
+    node_set = unique(collect_nodes(func))
+    (node_set == [node] || length(node_set) == 0) || error("Optinode does not own all variables.")
     d = JuMP.object_dictionary(node)
     d[(node, :objective_sense)] = sense
     d[(node, :objective_function)] = func
@@ -227,7 +228,8 @@ end
 
 function JuMP.set_objective_function(node::OptiNode, func::JuMP.AbstractJuMPScalar)
     # check that all func terms are for this node
-    unique(collect_nodes(func)) == [node] || error("Optinode does not own all variables.")
+    node_set = unique(collect_nodes(func))
+    (node_set == [node] || length(node_set) == 0) || error("Optinode does not own all variables.")
     d = JuMP.object_dictionary(node)
     d[(node, :objective_function)] = func
     return nothing


### PR DESCRIPTION
I found that the code below gave an error when I called `aggregate`. It appeared to be caused by [this line](https://github.com/plasmo-dev/Plasmo.jl/blob/0bfd466dcf38256cba1f7075ad5b3d874a175872/src/optinode.jl#L221) because the objective function being passed was zero and so was not attached to any specific node. I added a second OR statement so that it also allows for the objective to be zero. In addition, I added a `@warn` statement to the aggregate function so that, if the graph has no objective function but the nodes do, the user is warned that the objectives will be lost in the aggregation. 

MWE: 
```julia
using JuMP, Plasmo, HiGHS
g = OptiGraph()
@optinode(g, nodes[1:4])

for node in nodes
    @variable(node, 0 <= x)
    @objective(node, Min, x)
end
@linkconstraint(g, nodes[1][:x] + nodes[2][:x] >= 1)
@linkconstraint(g, nodes[2][:x] + nodes[3][:x] >= 1)
@linkconstraint(g, nodes[3][:x] + nodes[4][:x] >= 1)
@linkconstraint(g, nodes[4][:x] + nodes[1][:x] >= 1)

node_membership_vector = [1, 1, 2, 2]
partition = Plasmo.Partition(g, node_membership_vector)

apply_partition!(g, partition)
#set_to_node_objectives(g)

agg_graph, agg_map = aggregate(g)
```