### PR TITLE
Added `JuMP.delete` extension for link constraints

### DIFF
--- a/src/optiedge.jl
+++ b/src/optiedge.jl
@@ -94,6 +94,10 @@ function JuMP.delete(graph::OptiGraph, cref::ConstraintRef)
     #TODO: Probably need to delete the edge altogether if it is the only constraint on the edge
 end
 
+function JuMP.unregister(graph::OptiGraph, key::Symbol)
+    delete!(object_dictionary(graph), key)
+end
+
 ### Edge Constraints
 
 # NOTE: could use one method for node and edge

--- a/src/optiedge.jl
+++ b/src/optiedge.jl
@@ -76,6 +76,24 @@ function JuMP.all_variables(edge::OptiEdge)
     return unique(vars)
 end
 
+function JuMP.delete(graph::OptiGraph, cref::ConstraintRef)
+    if typeof(JuMP.owner_model(cref)) == OptiNode{OptiGraph}
+        error(
+            "You have passed a node constraint but specified an OptiGraph." *
+            "Use `JuMP.delete(::OptiNode, ::ConstraintRef)` instead",
+        )
+    end
+    if graph !== source_graph(JuMP.owner_model(cref))
+        error(
+            "The constraint reference you are trying to delete does not" *
+            "belong to the specified graph",
+        )
+    end
+    _set_dirty(graph)
+    MOI.delete(JuMP.owner_model(cref), cref)
+    #TODO: Probably need to delete the edge altogether if it is the only constraint on the edge
+end
+
 ### Edge Constraints
 
 # NOTE: could use one method for node and edge

--- a/src/optiedge.jl
+++ b/src/optiedge.jl
@@ -76,26 +76,11 @@ function JuMP.all_variables(edge::OptiEdge)
     return unique(vars)
 end
 
-function JuMP.delete(graph::OptiGraph, cref::ConstraintRef)
-    if typeof(JuMP.owner_model(cref)) == OptiNode{OptiGraph}
-        error(
-            "You have passed a node constraint but specified an OptiGraph." *
-            "Use `JuMP.delete(::OptiNode, ::ConstraintRef)` instead",
-        )
+function _set_dirty(edge::OptiEdge)
+    for graph in containing_optigraphs(edge)
+        graph.is_model_dirty = true
     end
-    if graph !== source_graph(JuMP.owner_model(cref))
-        error(
-            "The constraint reference you are trying to delete does not" *
-            "belong to the specified graph",
-        )
-    end
-    _set_dirty(graph)
-    MOI.delete(JuMP.owner_model(cref), cref)
-    #TODO: Probably need to delete the edge altogether if it is the only constraint on the edge
-end
-
-function JuMP.unregister(graph::OptiGraph, key::Symbol)
-    delete!(object_dictionary(graph), key)
+    return nothing
 end
 
 ### Edge Constraints

--- a/src/optielement.jl
+++ b/src/optielement.jl
@@ -144,3 +144,15 @@ function JuMP.all_constraints(
     end
     return constraints
 end
+
+function JuMP.delete(element::OptiElement, cref::ConstraintRef)
+    if element !== JuMP.owner_model(cref)
+        error(
+            "The constraint reference you are trying to delete does not " *
+            "belong to the model.",
+        )
+    end
+    _set_dirty(element)
+    MOI.delete(element, cref)
+    return nothing
+end

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -1423,3 +1423,7 @@ function _set_objective_coefficient(
     )
     return nothing
 end
+
+function _set_dirty(graph::OptiGraph)
+    graph.is_model_dirty = true
+end

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -1424,6 +1424,6 @@ function _set_objective_coefficient(
     return nothing
 end
 
-function _set_dirty(graph::OptiGraph)
-    graph.is_model_dirty = true
+function JuMP.unregister(graph::OptiGraph, key::Symbol)
+    delete!(object_dictionary(graph), key)
 end

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -121,18 +121,6 @@ function JuMP.all_variables(node::OptiNode)
     return NodeVariableRef.(Ref(node), var_inds)
 end
 
-function JuMP.delete(node::OptiNode, cref::ConstraintRef)
-    if node !== JuMP.owner_model(cref)
-        error(
-            "The constraint reference you are trying to delete does not " *
-            "belong to the model.",
-        )
-    end
-    _set_dirty(node)
-    MOI.delete(node, cref)
-    return nothing
-end
-
 function JuMP.unregister(node::OptiNode, key::Symbol)
     delete!(object_dictionary(node), (node, key))
 end

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -133,6 +133,10 @@ function JuMP.delete(node::OptiNode, cref::ConstraintRef)
     return nothing
 end
 
+function JuMP.unregister(node::OptiNode, key::Symbol)
+    delete!(object_dictionary(node), (node, key))
+end
+
 ### Duals
 
 """

--- a/test/test_optigraph.jl
+++ b/test/test_optigraph.jl
@@ -440,6 +440,24 @@ function test_nlp_exceptions()
     @test_throws Exception @NLconstraint(graph, graph[1][:x]^3 >= 0)
 end
 
+function test_delete_extensions()
+    graph = OptiGraph()
+    @optinode(graph, nodes[1:2])
+
+    @variable(nodes[1], x >= 1)
+    @variable(nodes[2], x >= 2)
+    @constraint(nodes[1], n_con, nodes[1][:x]^2 >= 1)
+    @linkconstraint(graph, l_con, nodes[1][:x] + nodes[2][:x] == 4)
+
+    @test_throws ErrorException JuMP.delete(graph, n_con)
+    @test_throws ErrorException JuMP.delete(nodes[1], l_con)
+
+    JuMP.delete(nodes[1], n_con)
+    @test !(n_con in all_constraints(nodes[1]))
+    JuMP.delete(graph, l_con)
+    @test !(l_con in all_link_constraints(graph))
+end
+
 function run_tests()
     for name in names(@__MODULE__; all=true)
         if !startswith("$(name)", "test_")

--- a/test/test_optigraph.jl
+++ b/test/test_optigraph.jl
@@ -449,12 +449,14 @@ function test_delete_extensions()
     @constraint(nodes[1], n_con, nodes[1][:x]^2 >= 1)
     @linkconstraint(graph, l_con, nodes[1][:x] + nodes[2][:x] == 4)
 
-    @test_throws ErrorException JuMP.delete(graph, n_con)
+    edge = JuMP.owner_model(l_con)
+
+    @test_throws ErrorException JuMP.delete(edge, n_con)
     @test_throws ErrorException JuMP.delete(nodes[1], l_con)
 
     JuMP.delete(nodes[1], n_con)
     @test !(n_con in all_constraints(nodes[1]))
-    JuMP.delete(graph, l_con)
+    JuMP.delete(edge, l_con)
     @test !(l_con in all_link_constraints(graph))
 end
 


### PR DESCRIPTION
Added the `JuMP.delete` extension for link constraints so that you can delete a link constraint on an edge from a graph. I also added some tests for `JuMP.delete` for both nodes and edges. 