### PR TITLE
Fixed formatting issues in examples

### DIFF
--- a/docs/src/tutorials/quadcopter.md
+++ b/docs/src/tutorials/quadcopter.md
@@ -239,10 +239,9 @@ plot(
     label = ["Current X position" "X Setpoint"]
 )
 ```
-
-<img src = "../assets/Quadcopter_Xpos.png" alt = "drawing" width = "600"/>
-<img src = "../assets/Quadcopter_Ypos.png" alt = "drawing" width = "600"/>
-<img src = "../assets/Quadcopter_Zpos.png" alt = "drawing" width = "600"/>
+![QuadcopterXpos](../assets/Quadcopter_Xpos.png)
+![QuadcopterYpos](../assets/Quadcopter_Ypos.png)
+![QuadcopterZpos](../assets/Quadcopter_Zpos.png)
 
 Now that we have solved for the optimal solution, let's explore a correlation. Let's see how increasing the number of nodes changes the objective value of the system. In the code snippet below, we keep the time horizon the same (10 seconds) while changing the number of nodes (i.e., the discretization intervals)
 ```julia
@@ -270,7 +269,4 @@ Quad_Obj_NN = plot(
 )
 ```
 
-<img src = "../assets/Quadcopter_Obj_NN.png" alt = "drawing" width = "600"/>
-
-
-
+![Quadcopter_Ojb](../assets/Quadcopter_Obj_NN.png)

--- a/docs/src/tutorials/supply_chain.md
+++ b/docs/src/tutorials/supply_chain.md
@@ -6,12 +6,12 @@ This tutorial shows how to model a supply chain using Plasmo.jl. This problem ha
 
 The supply chain being modeled includes a set of suppliers and consumers, where the suppliers ship products to technologies (for product conversion) or directly to the consumers. Suppliers, consumers, and technologies are located at specific locations (represented by nodes) with varying transportation capacity and costs between nodes. This problem includes the following sets: 
 
- * $P$ - Products
- * $S$ - Suppliers
- * $D$ - Demands
- * $L$ - Lines (for transporting products)
- * $T$ - Technologies
- * $N$ - Nodes (locations)
+ * Products ($P$)
+ * Suppliers ($S$)
+ * Demands ($D$)
+ * Lines for transporting products ($L$)
+ * Technologies ($T$)
+ * Nodes/Locations ($N$)
 
 Each supplier and consumer only sells or consumes a single product. In addition $L$ connects two nodes in $N$ and has an associated direction (i.e., this is a directed graph). As each supplier, consumer, and technology are located at a specific node, we will denote these objects at a given node $n \in N$ by $S(n)$, $D(n)$, and $T(n)$, and we will denote the set of all lines originating at node $n$ as $L_{in}(n)$ and the set of all lines ending at at node $n$ as $L_{out}(n)$. We will also add superscripts to these sets for specific products when applicable (e.g., $D^p(n)$ represents the consumers at node $n \in N$ that consume product $p \in P$). Mathematically, this multi-product supply chain problem is given by:
 
@@ -188,8 +188,9 @@ The form of this graph network is visualized below, where the (hyper)edges conta
 ![sc_optigraph](../assets/sc_optigraph.png)
 
 Finally, we set the optimizer on the graph and the overall objective on the graph. 
-> [!NOTE] 
-> After the changes made between Plasmo v0.5.4 and v0.6.0, we must now include the function `set_to_node_objectives(graph)` in the script below to set the graph's objective to use the individual node objectives. In former versions of Plasmo, the graph used the node objectives automatically. 
+
+!!! note
+    After the changes made between Plasmo v0.5.4 and v0.6.0, we must now include the function `set_to_node_objectives(graph)` in the script below to set the graph's objective to use the individual node objectives. In former versions of Plasmo, the graph used the node objectives automatically. 
 
 ```julia
 set_optimizer(graph, HiGHS.Optimizer)


### PR DESCRIPTION
There were some minor formatting issues in the examples, including the Note flag not showing up properly, the bullets in the supply chain looking funny, and the figures not showing up as intended in the quadcopter example. I believe this PR resolves all three issues. 