### PR TITLE
Removed inefficient `setdiff` calls

### DIFF
--- a/src/backends/moi_backend.jl
+++ b/src/backends/moi_backend.jl
@@ -889,7 +889,6 @@ function _copy_node_variables(
     # add new MOI variables to the destination MOI backend
     # note that existing node variables are not copied per-se; the references
     # now point to multiple MOI backends.
-    vars_to_add = setdiff(node_variables, keys(dest.element_to_graph_map.var_map))
     for var in node_variables
         if !(var in keys(dest.element_to_graph_map))
             src_graph_index = graph_index(var)

--- a/src/backends/moi_backend.jl
+++ b/src/backends/moi_backend.jl
@@ -592,7 +592,7 @@ end
 # Graph MOI Utilities
 #
 
-# NOTE: These utilities are meant to take model expressions defined over optinodes and 
+# NOTE: These utilities are meant to take model expressions defined over optinodes and
 # map them to the underlying optigraph backend indices. This way, nodes and edges
 # can be mapped to multiple possible optigraph backends.
 
@@ -718,9 +718,10 @@ function _add_backend_variables(backend::GraphMOIBackend, var::NodeVariableRef)
 end
 
 function _add_backend_variables(backend::GraphMOIBackend, vars::Vector{NodeVariableRef})
-    vars_to_add = setdiff(vars, keys(backend.element_to_graph_map.var_map))
-    for var in vars_to_add
-        MOI.add_variable(backend, var)
+    for var in vars
+        if !(var in keys(backend.element_to_graph_map.var_map))
+            MOI.add_variable(backend, var)
+        end
     end
     return nothing
 end
@@ -760,8 +761,8 @@ end
 # Aggregate MOI backends
 #
 
-# Note that these methods do not create copies of nodes or edges; they create model 
-# data for new backends. The nodes and edges will then reference data for multiple backends. 
+# Note that these methods do not create copies of nodes or edges; they create model
+# data for new backends. The nodes and edges will then reference data for multiple backends.
 
 """
     _copy_subgraph_backends!(graph::OptiGraph)

--- a/src/backends/moi_backend.jl
+++ b/src/backends/moi_backend.jl
@@ -890,7 +890,7 @@ function _copy_node_variables(
     # note that existing node variables are not copied per-se; the references
     # now point to multiple MOI backends.
     for var in node_variables
-        if !(var in keys(dest.element_to_graph_map))
+        if !(var in keys(dest.element_to_graph_map.var_map))
             src_graph_index = graph_index(var)
             dest_graph_index = MOI.add_variable(dest, var)
             index_map[src_graph_index] = dest_graph_index

--- a/src/backends/moi_backend.jl
+++ b/src/backends/moi_backend.jl
@@ -890,10 +890,12 @@ function _copy_node_variables(
     # note that existing node variables are not copied per-se; the references
     # now point to multiple MOI backends.
     vars_to_add = setdiff(node_variables, keys(dest.element_to_graph_map.var_map))
-    for var in vars_to_add
-        src_graph_index = graph_index(var)
-        dest_graph_index = MOI.add_variable(dest, var)
-        index_map[src_graph_index] = dest_graph_index
+    for var in node_variables
+        if !(var in keys(dest.element_to_graph_map))
+            src_graph_index = graph_index(var)
+            dest_graph_index = MOI.add_variable(dest, var)
+            index_map[src_graph_index] = dest_graph_index
+        end
     end
 
     # pass variable attributes


### PR DESCRIPTION
This PR addresses #124. Adding link constraints to a graph with lots of variables was inefficient because of the `setdiff` call that was called by the `_add_backend_variables` function (called by `MOI.add_constraint`). I replaced the `setdiff` with a for loop that tests whether the variable is in the keys of `backend.element_to_graph_map.var_map` rather than building a new vector of these variables first. The code snippet in #124 now works much quicker and the time for running each iteration of the loop in that issue no longer increases after each iteration. 