### PR TITLE
Fixed bug in relax_integrality

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: actions/cache@v1
+      - uses: actions/cache@v4
         env:
           cache-name: cache-artifacts
         with:

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -308,8 +308,8 @@ function _relax_or_fix_integrality(var_value::Union{Nothing,Function}, node::Opt
         elseif info.binary
             JuMP.unset_binary(v)
             if !info.has_fix
-                JuMP.set_lower_bound(v, max(zero(T), info.lower_bound))
-                JuMP.set_upper_bound(v, min(one(T), info.upper_bound))
+                JuMP.set_lower_bound(v, max(zero(Float64), info.lower_bound))
+                JuMP.set_upper_bound(v, min(one(Float64), info.upper_bound))
             elseif info.fixed_value < 0 || info.fixed_value > 1
                 error(
                     "The model has no valid relaxation: binary variable " *

--- a/test/test_optigraph.jl
+++ b/test/test_optigraph.jl
@@ -422,6 +422,13 @@ function test_variable_constraints()
     @test is_binary(n1[:x]) == true
     @test is_integer(n2[:x]) == true
 
+    # relax and unrelax integrality for entire graph, unfixing x variables first
+    JuMP.unfix(n1[:x])
+    unrelax_graph = JuMP.relax_integrality(graph)
+    @test is_binary(n1[:x]) == false
+    unrelax_graph()
+    @test is_binary(n1[:x]) == true
+
     graph = OptiGraph()
 
     @optinode(graph, nodes[1:2])


### PR DESCRIPTION
There is an error in relax_integrality [here](https://github.com/plasmo-dev/Plasmo.jl/blob/8b272d543e99a72fd4b3803fbbfd9d9e8c652bf6/src/optinode.jl#L311-L312) because `T` is not defined. I replaced this with `Float64` since, as far as I can tell, Plasmo.jl is only set up with `Float64` as the basis for any of the values. I considered trying to use this more general `T` syntax, but it looks like this is not used very much elsewhere in the package. Open to using that syntax instead of setting `Float64` if you think that is better. 