### PR TITLE
Added `JuMP.write_to_file` function extension

### DIFF
--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -1495,7 +1495,8 @@ end
 
 Write the model stored in `graph` to `filename.` See [`MOI.FileFormats.FileFormat`](@ref) 
 for a list of supported formats. Format is determined automatically based on given file
-extension (e.g., .mps, .lp, .mof.json, .sdpa).
+extension (e.g., .mps, .lp, .mof.json, .sdpa). Note that this output does not explicitly
+include any graph structure information. 
 
 Plasmo does not support loading the file back into Julia as an OptiGraph.
 """

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -1490,6 +1490,28 @@ function JuMP.unregister(graph::OptiGraph, key::Symbol)
     return delete!(object_dictionary(graph), key)
 end
 
+"""
+    write_to_file(graph::OptiGraph, filename::string)
+
+Write the model stored in `graph` to `filename.` See [`MOI.FileFormats.FileFormat`](@ref) 
+for a list of supported formats. Format is determined automatically based on given file
+extension (e.g., .mps, .lp, .mof.json, .sdpa).
+
+Plasmo does not support loading the file back into Julia as an OptiGraph.
+"""
+function JuMP.write_to_file(graph::OptiGraph, filename::String)
+    m = MOI.FileFormats.Model(filename=filename)
+    f = () -> MOI.FileFormats.Model(filename=filename)
+
+    inner = MOI.instantiate(f)
+    moi_graph_model = graph.backend.moi_backend.model_cache.model
+
+    innter_map = MOI.copy_to(inner, moi_graph_model)
+    inner_backend = JuMP.unsafe_backend(inner)
+
+    MOI.write_to_file(inner_backend, filename)
+end
+
 # TODO Methods
 # num_linked_variables(graph)
 # linked_variables(graph)


### PR DESCRIPTION
Added an implementation of `JuMP.write_to_file.` This was mentioned by #140. I also had someone else reach out to me about adding this extension because they wanted to view the model as a text file (with `.lp` file extension). I noted in the doc string that this cannot be loaded back into Plasmo as an OptiGraph.