### PR TITLE
Update node hashing to support `distribute_optigraph` function

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Plasmo"
 uuid = "d3f7391f-f14a-50cc-bbe4-76a32d1bad3c"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["Jordan Jalving <jhjalving@gmail.com>"]
 repo = "https://github.com/plasmo-dev/Plasmo.jl.git"
 

--- a/docs/src/documentation/distributed_quickstart.md
+++ b/docs/src/documentation/distributed_quickstart.md
@@ -96,6 +96,48 @@ One note to make is that Plasmo returns light references to objects that are act
 
 In addition, two types of edges exist for `RemoteOptiGraph`s. The first is an `RemoteEdgeRef` which represents an edge stored on the remote worker inside the `OptiGraph`. In contrast, the `InterWorkerEdge` is an edge stored directly on the `RemoteOptiGraph` which connects the `OptiGraph` stored remotely with other subgraphs stored on the `RemoteOptiGraph`, or they connect multiple subgraphs stored on the `RemoteOptiGraph`.
 
+## Building Remote vs. Building Locally
+
+The RemoteOptiGraph is designed so as to capture problem structure for problems distributed to multiple workers. Different modeling paradigms could be used for constructing a RemoteOptiGraph, and users may choose different approaches to constructing the same problem. For instance, a user could build a graph locally and then distribute to remote processors, or they could directly construct the graph on the remote processors (see suggestion #3 below). For large-scale applications, it is recommended that users build the graph remotely to avoid serialization time and to potentially better parallelize model construction. 
+
+For benchmarking, Plasmo does support building an OptiGraph locally and then distributing its graphs to a remote worker via the `distribute_graph` function. This function is not recommended for extremely large models, but an example of its use is given below.
+
+```julia
+using Distributed
+addprocs(1)
+@everywhere begin
+    using Plasmo, HiGHS, Distributed
+end
+
+# Generate toy graph
+g = OptiGraph()
+g1 = OptiGraph()
+g2 = OptiGraph()
+
+@optinode(g1, n1); @optinode(g2, n2);
+@variable(n1, 0 <= x[1:10]); @variable(n2, 0 <= y[1:10]);
+@objective(n1, Min, sum(x[i] * i for i in 1:10))
+@objective(n2, Min, sum(y));
+
+add_subgraph(g, g1)
+add_subgraph(g, g2)
+
+@linkconstraint(g, [i in 1:10], n1[:x][i] + n2[:y][i] >= 5)
+
+# Distribute both g1 and g2 to remote worker 2
+rg = distribute_graph(g, [2, 2])
+
+remote_subgraphs = local_subgraphs(rg)
+rg1 = remote_subgraphs[1] # corresponds to g1
+rg2 = remote_subgraphs[2] # corresponds to g2
+
+rn1 = rg1[:n1] # RemoteNodeRef for n1
+rn2 = rg2[:n2] # RemoteNodeRef for n2
+
+rx = rn1[:x] # vector of RemoteVariableRef for x
+ry = rn2[:y] # vector of RemoteVariableRef for y
+```
+
 ## Performance Tips and Suggestions
 
 #### 1. Remember that each macro call is a separate call to the remote
@@ -104,7 +146,7 @@ Plasmo's `RemoteOptiGraph` object can be used in place of a normal `OptiGraph` o
 
 #### 2. Remember that some functions serialize larger objects between workers than other functions
 
-The larger the objects that are shared across workers, the slower the code will be, and not all functions will use the same amount of overhead. As an example, calling `all_variables` on a `RemoteOptiGraph` will create `RemoteVariableRef` objects for every variable on the graph, and it will share between the workers information for creating all variables (names as symbols and indices essentially as integers). In an ordinary JuMP model, calling `length(all_variables(m))` for a model `m` may not have noticeable overhead to it if a user only calls this once or twice, but calling `length(all_variables(g))` for a remote graph `g` may be noticeably slower since it is building `RemoteVariableRef`s for all variables on the graph. While this is best practice for both JuMP models and Plasmo `RemoteOptiGraph`s, using `JuMP.num_variables(g)` will be proportionally far more efficient in the case of the `RemoteOptiGraph` than it would be for a JuMP model.
+The larger the objects that are shared across workers, the slower the code will be, and not all functions will use the same amount of overhead. As an example, calling `all_variables` on a `RemoteOptiGraph` will create `RemoteVariableRef` objects for every variable on the graph, and it will share between the workers information for creating all variables (names as symbols and indices essentially as integers). In an ordinary JuMP model, calling `length(all_variables(m))` for a model `m` may not have noticeable overhead to it if a user only calls this once or twice, but calling `length(all_variables(g))` for a remote graph `g` may be noticeably slower since it is building `RemoteVariableRef`s for all variables on the graph. While it is best practice for both JuMP models and Plasmo `RemoteOptiGraph`s, using `JuMP.num_variables(g)` will be proportionally far more efficient in the case of the `RemoteOptiGraph` than it would be for a JuMP model.
 
 #### 3. Consider defining custom build functions
 

--- a/docs/src/documentation/distributed_quickstart.md
+++ b/docs/src/documentation/distributed_quickstart.md
@@ -98,9 +98,9 @@ In addition, two types of edges exist for `RemoteOptiGraph`s. The first is an `R
 
 ## Building Remote vs. Building Locally
 
-The RemoteOptiGraph is designed so as to capture problem structure for problems distributed to multiple workers. Different modeling paradigms could be used for constructing a RemoteOptiGraph, and users may choose different approaches to constructing the same problem. For instance, a user could build a graph locally and then distribute to remote processors, or they could directly construct the graph on the remote processors (see suggestion #3 below). For large-scale applications, it is recommended that users build the graph remotely to avoid serialization time and to potentially better parallelize model construction. 
+The RemoteOptiGraph is designed so as to capture problem structure for problems distributed to multiple workers. Different modeling paradigms could be used for constructing a RemoteOptiGraph, and users may choose different approaches to construct the same problem. For instance, a user could build a graph locally and then distribute to remote processors, or they could directly construct the graph on the remote processors (see suggestion #3 below). For large-scale applications, it is recommended that users build the graph remotely to avoid serialization time and to potentially better parallelize model construction. 
 
-For benchmarking, Plasmo does support building an OptiGraph locally and then distributing its graphs to a remote worker via the `distribute_graph` function. This function is not recommended for extremely large models, but an example of its use is given below.
+For benchmarking, Plasmo does support building an OptiGraph locally and then distributing its graphs to a remote worker via the `distribute_graph` function. This function is not recommended for very large models, but an example of its use is given below.
 
 ```julia
 using Distributed

--- a/src/core_types.jl
+++ b/src/core_types.jl
@@ -32,6 +32,7 @@ struct OptiNode{GT<:AbstractOptiGraph} <: AbstractOptiNode
     source_graph::Base.RefValue{<:GT}
     idx::NodeIndex
     label::Base.RefValue{Symbol}
+    node_hash::UInt
 end
 
 """

--- a/src/distributed/distribute_optigraph.jl
+++ b/src/distributed/distribute_optigraph.jl
@@ -129,14 +129,25 @@ end
 
 function distribute_graph(graph::OptiGraph, workers::Vector{Int})
     subgraphs = local_subgraphs(graph)
-    @assert length(subgraphs) == length(workers)
+    if any(i -> MOIU.state(i.backend) != MOIU.NO_OPTIMIZER, subgraphs)
+        @warn "One or more subgraphs have an optimizer attached; distributing the graph can be slower if optimizers are attached to subgraphs. Consider attaching optimizers after distribution."
+    end
+    @assert length(subgraphs) == length(workers) 
     graph_map = Dict{OptiGraph,RemoteOptiGraph}()
     rgraph = RemoteOptiGraph()
+    darrays = Vector{DArray}(undef, length(subgraphs))
+    @sync for (i, g) in enumerate(subgraphs)
+        g.parent_graph = nothing
+        @async begin
+            darray = distribute([g], procs=[workers[i]])
+            darrays[i] = darray
+        end
+    end
+
     for i in 1:length(workers)
-        darray = distribute([subgraphs[i]]; procs=[workers[i]])
         new_rgraph = RemoteOptiGraph(
             workers[i],
-            darray,
+            darrays[i],
             nothing,
             Vector{RemoteOptiGraph}(),
             Vector{Plasmo.InterWorkerEdge}(),

--- a/src/distributed/distribute_optigraph.jl
+++ b/src/distributed/distribute_optigraph.jl
@@ -127,6 +127,17 @@ function _convert_local_to_remote(
     return func
 end
 
+"""
+    distribute_graph(graph::OptiGraph, workers::Vector{Int})
+
+Distributes the given `OptiGraph` across the specified workers. This function assumes that the `graph` is already partitioned into subgraphs
+and requires that the `workers` vector be equal in length to the number of local subgraphs of `graph`, and it assumes that the specified
+worker indices exist. This function will serialize each of the local subgraphs to the corresponding worker, and represent it with a 
+`RemoteOptiGraph`. It will also create the InterworkerEdges to represent the coupling constraints between subgraphs. 
+
+This function is recommended for benchmarking rather than for large-scale applications. For large-scale applications, it is recommended that
+the remote OptiGraphs be constructed directly on the workers. 
+"""
 function distribute_graph(graph::OptiGraph, workers::Vector{Int})
     subgraphs = local_subgraphs(graph)
     if any(i -> MOIU.state(i.backend) != MOIU.NO_OPTIMIZER, subgraphs)

--- a/src/distributed/optinode.jl
+++ b/src/distributed/optinode.jl
@@ -84,7 +84,7 @@ function add_node(rgraph::RemoteOptiGraph)
 
     f = @spawnat wid begin
         lgraph = localpart(darray)[1]
-        n = add_node(lgraph; index=Symbol(UUIDs.uuid4()))
+        n = add_node(lgraph)
         _convert_local_to_proxy(lgraph, n)
     end
     pnode = fetch(f)

--- a/src/node_variables.jl
+++ b/src/node_variables.jl
@@ -31,11 +31,11 @@ end
 # https://github.com/jump-dev/MathOptInterface.jl/issues/234#issuecomment-366868878
 # """
 function Base.hash(nvref::NodeVariableRef, h::UInt)
-    return hash(objectid(JuMP.owner_model(nvref)), hash(nvref.index.value, h))
+    return hash(JuMP.owner_model(nvref).node_hash, hash(nvref.index.value, h))
 end
 
 function Base.isequal(v1::NodeVariableRef, v2::NodeVariableRef)
-    return owner_model(v1) === owner_model(v2) && v1.index == v2.index
+    return owner_model(v1) == owner_model(v2) && v1.index == v2.index
 end
 
 function get_node(nvref::NodeVariableRef)

--- a/src/optigraph.jl
+++ b/src/optigraph.jl
@@ -182,10 +182,11 @@ the number of nodes in the graph.
 function add_node(
     graph::OptiGraph;
     label=Symbol(graph.label, Symbol(".n"), length(graph.optinodes) + 1),
-    index=Symbol(UUIDs.uuid4()),
+    index=UUIDs.uuid4(),
 )
-    node_index = NodeIndex(index)
-    node = OptiNode(Ref(graph), node_index, Ref(label))
+    node_index = NodeIndex(Symbol(index))
+    node_hash = isa(index, UUIDs.UUID) ? hash(index.value) : hash(index)
+    node = OptiNode(Ref(graph), node_index, Ref(label), node_hash)
     push!(graph.optinodes, node)
     add_node(graph_backend(graph), node)
     return node

--- a/src/optinode.jl
+++ b/src/optinode.jl
@@ -550,5 +550,5 @@ function Base.:(==)(node1::OptiNode, node2::OptiNode)
 end
 
 function Base.hash(node::OptiNode, h::UInt)
-    return hash((node.idx.value), h)
+    return hash(node.node_hash, h)
 end

--- a/test/test_distribute_optigraph.jl
+++ b/test/test_distribute_optigraph.jl
@@ -93,6 +93,25 @@ function test_distribute_optigraph()
     @test length(redge_con1.func) == length(constraint_object(lc1).func)
     @test length(redge_con2.func) == length(constraint_object(lc2).func)
     @test length(redge_con3.func) == length(constraint_object(lc3).func)
+    
+    set_optimizer(rsubgraphs[1], Ipopt.Optimizer)
+    set_optimizer(rsubgraphs[2], Ipopt.Optimizer)
+    set_optimizer(rsubgraphs[3], Ipopt.Optimizer)
+
+    # ensure that the subgraphs can be solved and are callable
+    @test try
+        optimize!(rsubgraphs[1])
+        optimize!(rsubgraphs[2])
+        optimize!(rsubgraphs[3])
+
+        true
+    catch
+        false
+    end
+
+    @test  isa(rsubgraphs[1][:n1][:x], RemoteVariableRef)
+    @test  isa(rsubgraphs[2][:n1][:x], RemoteVariableRef)
+    @test  isa(rsubgraphs[3][:n1][:x], RemoteVariableRef)
 end
 
 function run_tests()


### PR DESCRIPTION
The current version of `distribute_optigraph` does not work because of hashing issues between the local and remote workers. `NodeVariableRef` objects are used as keys to dictionaries in the backend, but `NodeVariableRef`s are hashed on the `objectid` of the node, which is not consistent across workers. This leads to the new remote optigraph not being usable as calls to the OptiGraph on the worker often result in errors (see #151). 

This PR makes some changes to the node struct and adds a `node_hash` attribute which uses the `UInt` value of the node's index (comes from a UUID, which essentially is just a wrapper of a `UInt`). There are also a couple small changes made to the `distribute_optigraph` function so that the subgraphs being distributed no longer reference the parent optigraph and the distribution can be done in parallel. 

The `distribute_optigraph` function supports the paradigm of building on the local machine and then distributing to the remote machines. In my testing, there is some significant overhead to distributing (my model with 12 million variables built in ~3 min and then took ~17 to distribute to the local workers), but it gives the user another way to do distributed optimization without having to directly interact with Distributed.jl to build their model. I think it is likely most efficient for the user to build their model directly on the remote, and if we only want to support that paradigm, this PR does not need to get merged. If we want to provide both the the user, this seems to be a reasonable way of doing it. The main downside of this PR is that there is a fourth attribute on all OptiNodes now. 